### PR TITLE
FIX does not insert images to activity / invalid sql query id IN ORDER BY 

### DIFF
--- a/app/helper/RTMediaModel.php
+++ b/app/helper/RTMediaModel.php
@@ -67,10 +67,10 @@ class RTMediaModel extends RTDBModel {
                         $compare = 'IN';
                     else
                         $compare = $colvalue[ 'compare' ];
-                    if ( ! isset ( $colvalue[ 'value' ] ) ) {
-                        $colvalue[ 'value' ] = $colvalue;
-                    }
-                    $col_val_comapare = ($colvalue[ 'value' ]) ? '(\'' . implode ( "','", $colvalue[ 'value' ] ) . '\')' : '';
+
+                    $tmpVal = isset ( $colvalue[ 'value' ] ) ? $colvalue[ 'value' ] : $colvalue;
+                    $col_val_comapare = (is_array($tmpVal)) ? '(\'' . implode ( "','", $tmpVal ) . '\')' : '';
+
                     $where .= " AND {$this->table_name}.{$colname} {$compare} {$col_val_comapare}";
                 }
                 else


### PR DESCRIPTION
When uploading an image with an activity, the html code for the image(s) is not written, the ul list is generated but contains no li items.

Debug:
RTMediaModel->get() is invoked with a columns array like array('id' => array(123)) - and this results in an invalid sql string like  "id IN ORDER BY " - the (123) is missing.

if ( ! isset ( $colvalue[ 'value' ] ) ) {
    $colvalue[ 'value' ] = $colvalue;
} 
Is invoked, but $colvalue[ 'value' ] does not contain a value and thus $col_val_comapare is empty.

This fix handles this case.
