### PR TITLE
Pass group id in "can_user_create_album_in_group" if set in $_POST

### DIFF
--- a/app/main/controllers/template/RTMediaAJAX.php
+++ b/app/main/controllers/template/RTMediaAJAX.php
@@ -24,7 +24,8 @@ class RTMediaAJAX {
         function create_album(){
             if ( isset($_POST['name']) && $_POST['name'] && is_rtmedia_album_enable()) {
                 if(isset($_POST['context']) && $_POST['context'] =="group"){
-                    if(can_user_create_album_in_group() == false){
+                    $group_id = !empty( $_POST['group_id']) ? $_POST['group_id'] : '';
+                    if(can_user_create_album_in_group($group_id) == false){
                         echo false;
                         wp_die();
                     }


### PR DESCRIPTION
can_user_create_album_in_group checks for current_group in bp, in case of back end the current group is null, because of which any request for new group album from user back end returns false.
