### PR TITLE
Display Group albums in list only if Buddypress is active

### DIFF
--- a/app/main/controllers/template/rt-template-functions.php
+++ b/app/main/controllers/template/rt-template-functions.php
@@ -1056,7 +1056,7 @@ function rtmedia_user_album_list ( $get_all = false ) {
     $option = "$global_option";
     if($profile_option != "")
     $option.= "<optgroup label='".__("Profile Albums","rtmedia")." ' value = 'profile'>$profile_option</optgroup>";
-    if($option_group != "")
+    if($option_group != "" && class_exists('BuddyPress') )
     $option.="<optgroup label='".__("Group Albums","rtmedia")."' value = 'group'>$option_group</optgroup>";
     if ( $option )
         return $option;


### PR DESCRIPTION
Display group albums in user album list only if buddypress is active to avoid confusion.
