### PR TITLE
Fix for php notice on Album delete success

### DIFF
--- a/app/main/controllers/media/RTMediaMedia.php
+++ b/app/main/controllers/media/RTMediaMedia.php
@@ -283,7 +283,7 @@ class RTMediaMedia {
             }
         }
 
-        if ( $status == 0 ) {
+        if ( !$status ) {
             return false;
         } else {
 	    global $rtmedia_points_media_id;


### PR DESCRIPTION
In case of album deletion, on success wp_delete_post returns a object and checking it against 0 for failure generates Notice:  Object of class stdClass could not be converted to int in /var/www/rtmediatest.local/htdocs/wp-content/plugins/buddypress-media/app/main/controllers/media/RTMediaMedia.php on line 286.

As on failure function returns false so we can just check if(!$status) { return false; }
