### PR TITLE
Pass user id for comment from $param ( required for API developments )

### DIFF
--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -75,22 +75,20 @@ class RTMediaBuddyPressActivity {
     }
     function comment_sync ( $comment_id, $param ) {
 
-        // comment_id 40
-        // Array( [id] => [content] => testing [user_id] => 1 [activity_id] => 26 [parent_id] => 26)
-
-//        $activity = new BP_Activity_Activity ( $param[ 'activity_id' ] );
-//        if ( $activity->type == 'rtmedia_update' ) {
-//            $media_id = $activity->item_id;
-//            $comment = new RTMediaComment();
-//            $comment->add ( array( 'comment_content' => $param[ 'content' ], 'comment_post_ID' => $media_id ) );
-//        }
+        $user_id = '';
+	$comment_author = '';
+        extract($param);
+	if( !empty($user_id) ){
+		$user_data = get_userdata($user_id);
+		$comment_author = $user_data->data->user_login;
+	}
 	$mediamodel = new RTMediaModel();
 	$media = $mediamodel->get(array('activity_id' => $param[ 'activity_id' ]));
 	// if there is only single media in activity
 	if(sizeof($media) == 1 && isset($media[0]->media_id)) {
 	    $media_id = $media[0]->media_id;
 	    $comment = new RTMediaComment();
-            $id = $comment->add ( array( 'comment_content' => $param[ 'content' ], 'comment_post_ID' => $media_id ) );
+            $id = $comment->add ( array( 'comment_content' => $param[ 'content' ], 'comment_post_ID' => $media_id, 'user_id' => $user_id, 'comment_author' => $comment_author ) );
             update_comment_meta($id, 'activity_id', $comment_id);
 	}
     }


### PR DESCRIPTION
In comment_sync function user_id is available in argument $param, for API development we need to pass this user id, as there is no value returned for get_current_id() in https://github.com/rtCamp/rtMedia/blob/master/app/main/controllers/media/RTMediaComment.php on line 64 for API requests.
