### PR TITLE
Pass User ID while calling insert_activity function for New  Media

### DIFF
--- a/app/main/controllers/media/RTMediaMedia.php
+++ b/app/main/controllers/media/RTMediaMedia.php
@@ -501,6 +501,7 @@ class RTMediaMedia {
         );
 	$action = apply_filters('rtmedia_buddypress_action_text_fitler',$action,$username,$count,$user->user_nicename,$media->media_type);
         $activity_args = array(
+            'user_id' => $user->ID,
             'action' => $action,
             'content' => $activity_content,
             'type' => 'rtmedia_update',


### PR DESCRIPTION
For API development, user is not logged in, hence no user_id is inserted for activity. So need to pass it directly from $user variable.
