### PR TITLE
Translatable activity messages and translatable date

### DIFF
--- a/languages/rtmedia.po
+++ b/languages/rtmedia.po
@@ -581,6 +581,24 @@ msgstr ""
 msgid "%s ago "
 msgstr ""
 
+#: app/main/controllers/template/rt-template-functions.php:2036
+msgid "1 second"
+msgid_plural "%s seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: app/main/controllers/template/rt-template-functions.php:2039
+msgid "1 minute"
+msgid_plural "%s minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: app/main/controllers/template/rt-template-functions.php:2041
+msgid "1 hour"
+msgid_plural "%s hours"
+msgstr[0] ""
+msgstr[1] ""
+
 #: app/main/controllers/api/RTMediaJsonApi.php:166
 msgid "username/password empty"
 msgstr ""


### PR DESCRIPTION
This functionality was already included in 3fa43445bf5ddf031f7a685739b4c8f2c9ad67dd and 9bd45484d6679917e961a57b1bea4ea37a840f4a but it is not included anymore in the rtmedia.po ... Are you sure you also extract `_n()` when building the .po files?

P.S. can you please make sure that the phrase "Bulk Edit" finds its way into GlotPress? 
