### PR TITLE
fix for 404 Error for titles on bbPress templates

### DIFF
--- a/app/main/routers/RTMediaRouter.php
+++ b/app/main/routers/RTMediaRouter.php
@@ -95,8 +95,7 @@ class RTMediaRouter {
         if ( $return ) {
             $wp_query->is_404 = false;
         }
-
-		if( isset( $rtmedia_query ) && isset( $rtmedia_query->query ) && ! isset($rtmedia_query->query['context']) ) {
+		if( !empty( $rtmedia_query ) && !empty( $rtmedia_query->query ) && empty($rtmedia_query->query['context']) ) {
 			$wp_query->is_404 = true;
 			$return = false;
 		}


### PR DESCRIPTION
-- Gives 404 Error instead of Forum or Topic titles
The solution here is to use "empty" function instead of "isset" inside the condition. Because the variables, $rtmedia_query, $rtmedia_query->query are initialized with blank values. So, isset is returning true for each condition. It is not checking whether the value is empty or not.
Hence, the solution is to change the condition:
`if( !empty( $rtmedia_query ) && !empty( $rtmedia_query->query ) && empty($rtmedia_query->query['context']) ) {`