### PR TITLE
Fixed issue of media move not working in album

### DIFF
--- a/templates/media/album-single-edit.php
+++ b/templates/media/album-single-edit.php
@@ -81,7 +81,7 @@ $rtmedia_media = $media[0];
 								<p class="rtmedia-move-container">
 									<?php $global_albums = rtmedia_get_site_option( 'rtmedia-global-albums' ); ?>
 									<span><?php esc_html_e( 'Move selected media to the album : ', 'buddypress-media' ); ?></span>
-									<select name="album" class="rtmedia-user-album-list"><?php rtmedia_user_album_list() ?></select>
+									<select name="album" class="rtmedia-user-album-list"><?php echo rtmedia_user_album_list() ?></select>
 									<input type="button" class="rtmedia-move-selected" name="move-selected"
 									       value="<?php esc_attr_e( 'Move Selected', 'buddypress-media' ); ?>"/>
 								</p>


### PR DESCRIPTION
Fixed issue of media move not working in album.
List of available albums to move media was empty.