### PR TITLE
Add clear input field code after file input error

### DIFF
--- a/app/assets/admin/js/settings.js
+++ b/app/assets/admin/js/settings.js
@@ -924,6 +924,7 @@ jQuery( document ).ready( function ( $ ) {
 					jQuery( '#debuglog' ).val( '' );
 					/* Show error in alert box. */
 					alert( 'ERRORS: ' + data.error );
+					event.target.value = null;
 				}
 			}
 		});


### PR DESCRIPTION
GL-283
When the file is selected in settings and if the alert message appears, the file input is not cleared after dismissing the alert box which leads to an error of incorrect file upload.