### PR TITLE
Fix media view on edit media

### DIFF
--- a/app/assets/css/rtmedia.css
+++ b/app/assets/css/rtmedia.css
@@ -3112,6 +3112,10 @@ a.rtmedia-upload-media-link {
   content: '';
 }
 
+div.rtmedia-media {
+  margin-top: 5%;
+}
+
 @media only screen and (min-width: 1025px) {
   .mfp-content .rtm-lightbox-container {
     display: -webkit-box;

--- a/app/assets/css/sass/_media-element.scss
+++ b/app/assets/css/sass/_media-element.scss
@@ -56,3 +56,7 @@
 		}
 	}
 }
+
+div.rtmedia-media {
+    margin-top: 5%;
+}

--- a/languages/buddypress-media.po
+++ b/languages/buddypress-media.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rtMedia for WordPress, BuddyPress and bbPress 4.6.7\n"
 "Report-Msgid-Bugs-To: https://rtmedia.io/support/\n"
-"POT-Creation-Date: 2021-10-04 05:50:59+00:00\n"
+"POT-Creation-Date: 2021-10-05 04:55:01+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -3042,18 +3042,18 @@ msgstr ""
 msgid "Invalid attribute passed for rtmedia_gallery shortcode."
 msgstr ""
 
-#: app/main/controllers/template/RTMediaTemplate.php:447
-#: app/main/controllers/template/RTMediaTemplate.php:576
-#: app/main/controllers/template/RTMediaTemplate.php:682
-#: app/main/controllers/template/RTMediaTemplate.php:902
+#: app/main/controllers/template/RTMediaTemplate.php:450
+#: app/main/controllers/template/RTMediaTemplate.php:579
+#: app/main/controllers/template/RTMediaTemplate.php:685
+#: app/main/controllers/template/RTMediaTemplate.php:905
 msgid "Ooops !!! Invalid access. No nonce was found !!"
 msgstr ""
 
-#: app/main/controllers/template/RTMediaTemplate.php:457
+#: app/main/controllers/template/RTMediaTemplate.php:460
 msgid "Media updated Sucessfully"
 msgstr ""
 
-#: app/main/controllers/template/RTMediaTemplate.php:476
+#: app/main/controllers/template/RTMediaTemplate.php:479
 msgid "Error in updating Media"
 msgstr ""
 


### PR DESCRIPTION
Media was overlapped on Media title.

Fixed by adding margin to media that will provide some space between media and its title.

Issue ref: #1006 