### PR TITLE
Fix when attachments were not getting deleted on activity delete

### DIFF
--- a/app/main/controllers/media/RTMediaMedia.php
+++ b/app/main/controllers/media/RTMediaMedia.php
@@ -472,7 +472,7 @@ class RTMediaMedia {
 				}
 			}
 
-			if ( ! $core && ! is_admin() ) {
+			if ( ! $core && ! ( isset( $GLOBALS['current_screen'] ) && $GLOBALS['current_screen']->in_admin() ) ) {
 				wp_delete_attachment( $media[0]->media_id, true );
 			}
 


### PR DESCRIPTION
Remove `is_admin()` condition and add a condition to check the `current_screen`.