### PR TITLE
Copy original "Post Update" button value

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1887,7 +1887,7 @@ function rtmedia_selected_file_list( plupload, file, uploader, error, comment_me
 				class : 'button',
 				name  : 'aw-whats-new-submit',
 				id    : 'aw-whats-new-submit',
-				value : 'Post Update'
+				value : new_button.val()
 			} );
 
 			new_submit_btn.replaceWith( new_button );

--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1887,7 +1887,7 @@ function rtmedia_selected_file_list( plupload, file, uploader, error, comment_me
 				class : 'button',
 				name  : 'aw-whats-new-submit',
 				id    : 'aw-whats-new-submit',
-				value : new_button.val()
+				value : new_submit_btn.val()
 			} );
 
 			new_submit_btn.replaceWith( new_button );


### PR DESCRIPTION
Instead of re-creating the Post Update button, copy its original value! Why? 
Because sometimes it has been translated and in that case the user would see the button value change to "Post Update" after picking the media to upload.