### PR TITLE
Fix GH-1591: Add is_multisite check before replacing image URL

### DIFF
--- a/app/helper/RTMediaActivityModel.php
+++ b/app/helper/RTMediaActivityModel.php
@@ -42,6 +42,8 @@ class RTMediaActivityModel extends RTDBModel {
 
 	/**
 	 * Get activity without setting blog_id.
+	 * This function is needed because there's no way to get activity of a different blog.
+	 * Existing get method sets blog_id to current blog.
 	 *
 	 * @since v4.6.4
 	 *

--- a/app/helper/RTMediaActivityModel.php
+++ b/app/helper/RTMediaActivityModel.php
@@ -41,6 +41,22 @@ class RTMediaActivityModel extends RTDBModel {
 	}
 
 	/**
+	 * Get activity without setting blog_id.
+	 *
+	 * @since v4.6.4
+	 *
+	 * @param array    $columns  Columns.
+	 * @param bool|int $offset   Offset.
+	 * @param bool|int $per_page Per page.
+	 * @param string   $order_by Order by.
+	 *
+	 * @return array Returned data.
+	 */
+	public function get_without_blog_id( $columns, $offset = false, $per_page = false, $order_by = 'activity_id DESC' ) {
+		return parent::get( $columns, $offset, $per_page, $order_by );
+	}
+
+	/**
 	 * Insert row.
 	 *
 	 * @param array $row Row data.

--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -427,9 +427,15 @@ function replace_aws_img_urls_from_activities( $content, $activity = '' ) {
 
 				$baseurl = $uploads['baseurl'];
 
+				$thumbnail_url = '';
 				if ( 0 === strpos( $url, $uploads['baseurl'] ) ) {
 					$thumbnail_url = $url;
-				} else {
+				} elseif ( ! is_multisite() ) {
+					/**
+					 * Code in this condition replaces AWS image URL with normal URL, which shouldn't happen in case of a multisite.
+					 * Because wp_upload_dir will give current site's uploads directory, which will be different for image of different subsite.
+					 */
+
 					$rtmedia_folder_name = apply_filters( 'rtmedia_upload_folder_name', 'rtMedia' );
 
 					$thumbnail_url = explode( $rtmedia_folder_name, $url );


### PR DESCRIPTION
When **rtAmazon S3** is active and user uploads image which offloads to Amazon S3, the media URL changes to AWS URL.
But when rtAmazon S3 is not active, rtMedia core changes the URL back to local media library URL, to avoid breaking the image.
This is causing broken link for inter site activities as `wp_uploads_dir` will return current site's uploads folder URL, which is different for each subsite.

The code in this PR gets uploads URL of a current activity's blog and uses that to replace the image URL, which now won't break the image.

Also added 1 function `get_without_blog_id` in `RTMediaActivityModel` class, because current get method sets `blog_id` to current blog by default, so there's no way to get activity of a different blog.

Fixes https://github.com/rtMediaWP/rtMedia/issues/1591