### PR TITLE
Fix GH-1657: Add hook documentation, add attachment_ids in rtmedia_after_add_media hook

### DIFF
--- a/app/main/controllers/media/RTMediaMedia.php
+++ b/app/main/controllers/media/RTMediaMedia.php
@@ -206,9 +206,20 @@ class RTMediaMedia {
 			$rtmedia_points_media_id = $media_ids[0];
 		}
 
+		/**
+		 * Action after a specific type of media is added from rtMedia.
+		 */
 		do_action( 'rtmedia_after_add_' . $rtmedia_type );
 
-		do_action( 'rtmedia_after_add_media', $media_ids, $file_object, $uploaded );
+		/**
+		 * Action after media is added from rtMedia.
+		 *
+		 * @param array $media_ids      rtMedia IDs.
+		 * @param array $file_object    File details.
+		 * @param array $uploaded       Uploaded media details.
+		 * @param array $attachment_ids Attachment IDs of uploaded media.
+		 */
+		do_action( 'rtmedia_after_add_media', $media_ids, $file_object, $uploaded, $attachment_ids );
 
 		return $media_ids;
 	}


### PR DESCRIPTION
- Add hook documentation comments
- Add `attachment_ids` in `rtmedia_after_add_media` hook

Fixes https://github.com/rtCamp/rtMedia/issues/1657