### PR TITLE
Fix GH-1662: Removes imageEdit.save call from save button, added it only when required

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -28,6 +28,24 @@ jQuery( function( $ ) {
 				media_children.remove();
 			}
 		});
+
+		/**
+		 * Remove imageEdit.save function call and add it only when image is being modified in WP editor.
+		 */
+		$( '#rtmedia_media_single_edit .rtm-button-save' ).on( 'click', function() {
+			var $media_id = $( '#rtmedia-editor-media-id' ).val();
+			var $nonce = $( '#rtmedia-editor-nonce' ).val();
+			if ( '' === $nonce.trim() || '' === $media_id.trim() ) {
+				return;
+			}
+			$media_id = parseInt( $media_id );
+			$media_head = $( '#media-head-' + $media_id );
+			if ( ! $media_head.length || 'undefined' === typeof $media_head.css( 'display' ) || 'none' !== $media_head.css( 'display' ).trim() ) {
+				return;
+			}
+
+			imageEdit.save( $media_id, $nonce );
+		} );
 	});
 	/**
 	 * End of issue 1059 fix

--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -35,7 +35,7 @@ jQuery( function( $ ) {
 		$( '#rtmedia_media_single_edit .rtm-button-save' ).on( 'click', function() {
 			var $media_id = $( '#rtmedia-editor-media-id' ).val();
 			var $nonce = $( '#rtmedia-editor-nonce' ).val();
-			if ( ( 'undefined' !== typeof $nonce && '' === $nonce.trim() ) || ( 'undefined' !== typeof $media_id && '' === $media_id.trim() ) ) {
+			if ( 'undefined' === typeof $nonce || '' === $nonce.trim() || 'undefined' === typeof $media_id || '' === $media_id.trim() ) {
 				return;
 			}
 

--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -35,9 +35,10 @@ jQuery( function( $ ) {
 		$( '#rtmedia_media_single_edit .rtm-button-save' ).on( 'click', function() {
 			var $media_id = $( '#rtmedia-editor-media-id' ).val();
 			var $nonce = $( '#rtmedia-editor-nonce' ).val();
-			if ( '' === $nonce.trim() || '' === $media_id.trim() ) {
+			if ( ( 'undefined' !== typeof $nonce && '' === $nonce.trim() ) || ( 'undefined' !== typeof $media_id && '' === $media_id.trim() ) ) {
 				return;
 			}
+
 			$media_id = parseInt( $media_id );
 			$media_head = $( '#media-head-' + $media_id );
 			if ( ! $media_head.length || 'undefined' === typeof $media_head.css( 'display' ) || 'none' !== $media_head.css( 'display' ).trim() ) {

--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -38,7 +38,6 @@ jQuery( function( $ ) {
 			if ( 'undefined' === typeof $nonce || '' === $nonce.trim() || 'undefined' === typeof $media_id || '' === $media_id.trim() ) {
 				return;
 			}
-
 			$media_id = parseInt( $media_id );
 			$media_head = $( '#media-head-' + $media_id );
 			if ( ! $media_head.length || 'undefined' === typeof $media_head.css( 'display' ) || 'none' !== $media_head.css( 'display' ).trim() ) {

--- a/templates/media/media-single-edit.php
+++ b/templates/media/media-single-edit.php
@@ -55,8 +55,8 @@
 						<?php do_action( 'rtmedia_add_edit_tab_content', rtmedia_type() ); ?>
 					</div>
 					<div class="rtmedia-editor-buttons">
-						<input type="hidden" id="rtmedia-editor-nonce" value="<?php echo esc_attr( $media_id_nonce ); ?>" />
-						<input type="hidden" id="rtmedia-editor-media-id" value="<?php echo esc_attr( $rtmedia_media->media_id ); ?>" />
+						<input type="hidden" id="rtmedia-editor-nonce" name="rtmedia-editor-nonce" value="<?php echo esc_attr( $media_id_nonce ); ?>" />
+						<input type="hidden" id="rtmedia-editor-media-id" name="rtmedia-editor-media-id" value="<?php echo esc_attr( $rtmedia_media->media_id ); ?>" />
 						<input type="submit" class="button rtm-button rtm-button-save" value="<?php esc_attr_e( 'Save', 'buddypress-media' ); ?>"/>
 						<a class="button rtm-button rtm-button-back" href="<?php rtmedia_permalink(); ?>"><?php esc_html_e( 'Back', 'buddypress-media' ); ?></a>
 					</div>

--- a/templates/media/media-single-edit.php
+++ b/templates/media/media-single-edit.php
@@ -55,9 +55,10 @@
 						<?php do_action( 'rtmedia_add_edit_tab_content', rtmedia_type() ); ?>
 					</div>
 					<div class="rtmedia-editor-buttons">
-						<input type="submit" class="button rtm-button rtm-button-save" onclick="imageEdit.save(<?php echo esc_attr( $rtmedia_media->media_id ) . ', \'' . esc_attr( $media_id_nonce ); ?>')" value="<?php esc_attr_e( 'Save', 'buddypress-media' ); ?>"/>
-						<a class="button rtm-button rtm-button-back"
-						href="<?php rtmedia_permalink(); ?>"><?php esc_html_e( 'Back', 'buddypress-media' ); ?></a>
+						<input type="hidden" id="rtmedia-editor-nonce" value="<?php echo esc_attr( $media_id_nonce ); ?>" />
+						<input type="hidden" id="rtmedia-editor-media-id" value="<?php echo esc_attr( $rtmedia_media->media_id ); ?>" />
+						<input type="submit" class="button rtm-button rtm-button-save" value="<?php esc_attr_e( 'Save', 'buddypress-media' ); ?>"/>
+						<a class="button rtm-button rtm-button-back" href="<?php rtmedia_permalink(); ?>"><?php esc_html_e( 'Back', 'buddypress-media' ); ?></a>
 					</div>
 				</div>
 			</form>


### PR DESCRIPTION
- Removes `imageEdit.save` function call from **Save** button and add it via JavaScript, only when image is being edited from WP editor.

Fixes https://github.com/rtCamp/rtMedia/issues/1662