### PR TITLE
Add rtmedia_update in editable activity types and reload page after rtmedia_update activity is saved

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -46,6 +46,31 @@ jQuery( function( $ ) {
 
 			imageEdit.save( $media_id, $nonce );
 		} );
+
+		/**
+		 * Reload page when rtmedia_update type of activity is edited.
+		 */
+		function filterBeaSaveSuccess() {
+			location.reload();
+		}
+		/**
+		 * Prefilters ajax call which saves edited activity content.
+		 * Needed with BuddyPress Edit Activity plugin.
+		 * https://wordpress.org/plugins/buddypress-edit-activity/
+		 */
+		$.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
+			if ( 'undefined' === typeof originalOptions || 'undefined' === typeof originalOptions.data || 'buddypress-edit-activity-save' !== originalOptions.data.action ) {
+				return;
+			}
+
+			if ( ! $( '#activity-' + originalOptions.data.activity_id ).hasClass( 'rtmedia_update' ) ) {
+				return;
+			}
+
+			// Change the callback function to our own function, which reloads the page.
+			originalOptions.success = filterBeaSaveSuccess;
+			options.success = filterBeaSaveSuccess;
+		} );
 	});
 	/**
 	 * End of issue 1059 fix

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -34,6 +34,8 @@ class RTMediaBuddyPressActivity {
 				// Code to show media with read more option.
 				add_filter( 'bp_activity_truncate_entry', array( $this, 'bp_activity_truncate_entry' ), 10, 3 );
 			}
+
+			add_filter( 'b_e_a_plugin_option_editable_types', array( $this, 'b_e_a_plugin_option_editable_types' ) );
 		}
 		add_action( 'bp_activity_comment_posted', array( $this, 'comment_sync' ), 10, 2 );
 		add_action( 'bp_activity_delete_comment', array( $this, 'delete_comment_sync' ), 10, 2 );
@@ -74,6 +76,25 @@ class RTMediaBuddyPressActivity {
 			add_action( 'bp_activity_after_save', array( $this, 'bp_activity_after_save' ) );
 			add_action( 'bp_activity_after_delete', array( $this, 'bp_activity_after_delete' ) );
 		}
+	}
+
+	/**
+	 * Adds rtmedia_update in editable activity types when BuddyPress Edit Activity plugin is active.
+	 *
+	 * @param array $option Editable activity types.
+	 *
+	 * @return array Modified editable activity types.
+	 */
+	public function b_e_a_plugin_option_editable_types( $option ) {
+		if ( empty( $option ) || ! is_array( $option ) ) {
+			$option = array();
+		}
+
+		if ( ! in_array( 'rtmedia_update', $option, true ) ) {
+			$option[] = 'rtmedia_update';
+		}
+
+		return $option;
 	}
 
 	/**

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -35,7 +35,7 @@ class RTMediaBuddyPressActivity {
 				add_filter( 'bp_activity_truncate_entry', array( $this, 'bp_activity_truncate_entry' ), 10, 3 );
 			}
 
-			add_filter( 'b_e_a_plugin_option_editable_types', array( $this, 'b_e_a_plugin_option_editable_types' ) );
+			add_filter( 'b_e_a_plugin_option_editable_types', array( $this, 'rtmedia_bea_plugin_option_editable_types' ) );
 		}
 		add_action( 'bp_activity_comment_posted', array( $this, 'comment_sync' ), 10, 2 );
 		add_action( 'bp_activity_delete_comment', array( $this, 'delete_comment_sync' ), 10, 2 );
@@ -85,7 +85,7 @@ class RTMediaBuddyPressActivity {
 	 *
 	 * @return array Modified editable activity types.
 	 */
-	public function b_e_a_plugin_option_editable_types( $option ) {
+	public function rtmedia_bea_plugin_option_editable_types( $option ) {
 		if ( empty( $option ) || ! is_array( $option ) ) {
 			$option = array();
 		}


### PR DESCRIPTION
- Add `rtmedia_update` type of activity in editable activity types
- Reload page when `rtmedia_update` type of activity is edited and saved.

Fixes https://github.com/rtCamp/rtMedia/issues/1681