### PR TITLE
Fix GH-1704: Add support to post activity with media from sitewide activity stream from Nouveau template

### DIFF
--- a/app/assets/js/rtMedia.backbone.js
+++ b/app/assets/js/rtMedia.backbone.js
@@ -1468,16 +1468,29 @@ jQuery( document ).ready( function( $ ) {
 			var object  = '';
 			var item_id = 0;
 
-			if ( jQuery( '#whats-new-post-in' ).length ) {
-				item_id = jQuery( '#whats-new-post-in' ).val();
-			} else if ( jQuery( '.groups-header' ).length ) {
-				item_id = jQuery( '.groups-header' ).attr( 'data-bp-item-id' );
-			}
+			if ( 'legacy' === bp_template_pack ) {
+				if ( jQuery( '#whats-new-post-in' ).length ) {
+					item_id = jQuery( '#whats-new-post-in' ).val();
+				} else if ( jQuery( '.groups-header' ).length ) {
+					item_id = jQuery( '.groups-header' ).attr( 'data-bp-item-id' );
+				}
 
-			if ( item_id > 0 ) {
-				object = 'group';
+				if ( item_id > 0 ) {
+					object = 'group';
+				} else {
+					object = 'profile';
+				}
 			} else {
-				object = 'profile';
+				var whatsNewPostIn = jQuery( '#whats-new-post-in' );
+				if ( whatsNewPostIn.length ) {
+					object = whatsNewPostIn.val();
+					item_id = 0;
+				}
+
+				var contextData = jQuery( '#whats-new-post-in-box-items li.bp-activity-object.selected input[type="hidden"]' );
+				if ( contextData.length ) {
+					item_id = contextData.val();
+				}
 			}
 
 			up.settings.multipart_params.context = object;


### PR DESCRIPTION
Sets proper context_id and context when posting activity with media from sitewide activity stream in Nouveau template
Also allows to select a particular group to post media and activity to

Fixes https://github.com/rtCamp/rtMedia/issues/1704