### PR TITLE
Fixed issue of media tab is not showing in groups page

### DIFF
--- a/app/main/controllers/template/RTMediaNav.php
+++ b/app/main/controllers/template/RTMediaNav.php
@@ -131,7 +131,7 @@ class RTMediaNav {
 				$media_tab_position = apply_filters( 'rtmedia_group_media_tab_position', 99 );
 
 				//to solve an issue of Media Tab is not showing in version 10.0.0
-                $bp->version = floatval($bp->version);
+				$bp->version = floatval( $bp->version );
 
 				if ( isset( $bp->version ) && $bp->version > '2.5.3' ) {
 

--- a/app/main/controllers/template/RTMediaNav.php
+++ b/app/main/controllers/template/RTMediaNav.php
@@ -130,6 +130,9 @@ class RTMediaNav {
 				$slug               = apply_filters( 'rtmedia_group_media_tab_slug', RTMEDIA_MEDIA_SLUG );
 				$media_tab_position = apply_filters( 'rtmedia_group_media_tab_position', 99 );
 
+				//to solve an issue of Media Tab is not showing in version 10.0.0
+                $bp->version = floatval($bp->version);
+
 				if ( isset( $bp->version ) && $bp->version > '2.5.3' ) {
 
 					/**


### PR DESCRIPTION
In BuddyPress version 10.0.0 Media tab is not showing in Groups page.

To generate:-

1. Update/Install BuddyPress version 10.0.0
2. Go to the Groups page with this URL. https://website_name/groups/your_group_name/
3. After this you can see in navigation menu, Media tab will not display.
4. By this PR I have fixed this issue. So, after this PR Media will appear on Groups page.

Before = https://prnt.sc/26q0ggz
After = https://prnt.sc/26q0gva

It fixes issue [#1826](https://github.com/rtCamp/rtMedia/issues/1826) .