### PR TITLE
fixes issue 1827 - fav album height not working properly

### DIFF
--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -511,8 +511,7 @@ class RTMedia {
 		?>
 		.rtmedia-container ul.rtmedia-list li.rtmedia-list-item div.rtmedia-item-thumbnail {
 		width: <?php echo esc_attr( $media_width ); ?>;
-		height: <?php echo esc_attr( $media_height ); ?>;
-		line-height: <?php echo esc_attr( $media_height ); ?>;
+		max-height: <?php echo esc_attr( $media_height ); ?>;
 		}
 		.rtmedia-container ul.rtmedia-list li.rtmedia-list-item div.rtmedia-item-thumbnail img {
 		max-width: <?php echo esc_attr( $media_width ); ?>;


### PR DESCRIPTION
It fixes issue #1827
<img width="837" alt="CleanShot 2022-02-09 at 04 09 44@2x" src="https://user-images.githubusercontent.com/6803549/153084339-398b86ab-2fd3-4447-803b-0e525f08a2c4.png">
 