### PR TITLE
Fix date format references

### DIFF
--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -3463,7 +3463,7 @@ function rtmedia_convert_date( $_date ) {
 		return sprintf( $ago_text, $value );
 	} else {
 		// translators: %s: date format, see http://php.net/date.
-		return date_i18n( 'd F Y ', strtotime( $_date ), true );
+		return date_i18n( get_option( 'date_format' ), strtotime( $_date ), true );
 	}
 
 }


### PR DESCRIPTION
I fixed the date format in the "rtmedia_convert_date" function to refer to the WordPress dashboard date format settings. Now the date in the pop-up image window appears in the native language. @dxd5001