### PR TITLE
Fix bug (1316) of rtMedi-Pro plugin with liked media in shortcode

### DIFF
--- a/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
+++ b/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
@@ -264,9 +264,11 @@ class RTMediaGalleryShortcode {
 			if ( $authorized_member ) {  // if current user has access to view the gallery (when context is 'group').
 				global $rtmedia_query;
 
-				if ( ! $rtmedia_query ) {
-					$rtmedia_query = new RTMediaQuery( $attr['attr'] );
-				}
+				/**
+				 * Need to create new RTMediaQuery object to avoid conflict with previous shortcode query.
+				 * Otherwise, it will use previous query and will get wrong result.
+				 */
+				$rtmedia_query = new RTMediaQuery( $attr['attr'] );
 
 				do_action( 'rtmedia_shortcode_action', $attr['attr'] );// do extra stuff with attributes.
 				$page_number                         = ( get_query_var( 'pg' ) ) ? get_query_var( 'pg' ) : 1; // get page number.


### PR DESCRIPTION
# Fix the liked media bug in the shortcode

- Create a new object of the RTMediaQuery class for every shortcode function. 
- In the older version, the shortcode render function used the same RTMediaQuery object for every shortcode which produces the wrong query for liked media and gave the older result. 
- Now, for every shortcode render, there is a new RTMediaQuery object to fix this.

## Note
Please also check this [PR](https://github.com/rtCamp/rtMedia-Pro/pull/1357) first

## Related issues
- https://github.com/rtCamp/rtMedia-Pro/issues/1316

## Related PRs
- https://github.com/rtCamp/rtMedia-Pro/pull/1357