### PR TITLE
Multiple shortcodes cannot work on the same page

### DIFF
--- a/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
+++ b/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
@@ -158,10 +158,19 @@ class RTMediaGalleryShortcode {
 	 * Render a shortcode according to the attributes passed with it
 	 *
 	 * @param bool|array $attr Shortcode attributes.
+	 * @param null       $content Shortcode content.
+	 * @param string     $shortcode_tag Shortcode tag.
 	 *
 	 * @return bool|string
 	 */
-	public static function render( $attr ) {
+	public static function render( $attr, $content = null, $shortcode_tag = '' ) {
+		static $run_shortcode = false;
+
+		if ( true === $run_shortcode ) {
+			return '';
+		}
+
+		$run_shortcode = true;
 
 		if ( self::display_allowed() ) {
 


### PR DESCRIPTION
# Multiple shortcodes cannot work on the same page

- `rtmedia_gallery` shortcode is not working correctly when adding it more than once.
- Reason behind this is the pagination is designed that way.
- Tried to fix this and was able to with `backbone.js`, but it works only for the `Load More` type pagination.
- `1,2,3...6` numerical pagination is based on the URL. All data is loaded using the URL `/pg/2/`. 
- In this case, two different shortcodes with different pages will not work.
- So this PR adds restriction and prevents the shortcode from generating output if It is used more than once.