### PR TITLE
Fix PHP deprecation errors

### DIFF
--- a/app/admin/RTMediaAdmin.php
+++ b/app/admin/RTMediaAdmin.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 				echo '</script>';
 			}
 
-			$page_name = sanitize_text_field( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) );
+			$page_name = sanitize_text_field( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			if ( ! empty( $page_name ) && 'rtmedia-settings' === $page_name ) {
 				/**
@@ -1030,7 +1030,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 		 * @return string
 		 */
 		public static function get_current_tab() {
-			$page_name = sanitize_text_field( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) );
+			$page_name = sanitize_text_field( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			return isset( $page_name ) ? $page_name : 'rtmedia-settings';
 		}
 
@@ -1479,8 +1479,8 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 		 */
 		public function convert_videos_mailchimp_send() {
 			// todo: nonce required.
-			$interested = sanitize_text_field( filter_input( INPUT_POST, 'linkback', FILTER_SANITIZE_STRING ) );
-			$choice     = sanitize_text_field( filter_input( INPUT_POST, 'choice', FILTER_SANITIZE_STRING ) );
+			$interested = sanitize_text_field( filter_input( INPUT_POST, 'linkback', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$choice     = sanitize_text_field( filter_input( INPUT_POST, 'choice', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			$url        = filter_input( INPUT_POST, 'url', FILTER_SANITIZE_URL );
 			$email      = filter_input( INPUT_POST, 'email', FILTER_SANITIZE_EMAIL );
 
@@ -1510,7 +1510,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 		 * Function to save Video transcoding survey response.
 		 */
 		public function video_transcoding_survey_response() {
-			$survey_done = filter_input( INPUT_GET, 'survey-done', FILTER_SANITIZE_STRING );
+			$survey_done = filter_input( INPUT_GET, 'survey-done', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( isset( $survey_done ) && ( md5( 'survey-done' ) === $survey_done ) ) {
 				rtmedia_update_site_option( 'rtmedia-survey', 0 );
 			}
@@ -1655,7 +1655,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 		 * @return array $removable_query_args
 		 */
 		public function removable_query_args( $removable_query_args ) {
-			$page_name = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+			$page_name = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( isset( $page_name ) && 'rtmedia-settings' === $page_name ) {
 				$removable_query_args[] = 'settings-saved';
 			}
@@ -1672,7 +1672,7 @@ if ( ! class_exists( 'RTMediaAdmin' ) ) {
 		 */
 		public function rtm_addon_license_notice() {
 
-			$page_name = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+			$page_name = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			$args      = array(
 				'a' => array(
 					'href' => array(),

--- a/app/helper/RTMediaSettings.php
+++ b/app/helper/RTMediaSettings.php
@@ -24,7 +24,7 @@ if ( ! class_exists( 'RTMediaSettings' ) ) {
 			if ( ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 				add_action( 'admin_init', array( $this, 'settings' ) );
 
-				$rtmedia_option_save = filter_input( INPUT_POST, 'rtmedia-options-save', FILTER_SANITIZE_STRING );
+				$rtmedia_option_save = filter_input( INPUT_POST, 'rtmedia-options-save', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				if ( isset( $rtmedia_option_save ) ) {
 					add_action( 'init', array( $this, 'settings' ) );
 				}
@@ -214,7 +214,7 @@ if ( ! class_exists( 'RTMediaSettings' ) ) {
 			$options          = $this->sanitize_options( $options );
 			$rtmedia->options = $options;
 			// Save Settings first then proceed.
-			$rtmedia_option_save = filter_input( INPUT_POST, 'rtmedia-options-save', FILTER_SANITIZE_STRING );
+			$rtmedia_option_save = filter_input( INPUT_POST, 'rtmedia-options-save', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( isset( $rtmedia_option_save ) && current_user_can( 'manage_options' ) ) {
 				$options               = filter_input( INPUT_POST, 'rtmedia-options', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
 				$options               = $this->sanitize_before_save_options( $options );
@@ -226,7 +226,7 @@ if ( ! class_exists( 'RTMediaSettings' ) ) {
 					flush_rewrite_rules( false );
 				}
 				$settings_saved = '';
-				$setting_save   = filter_input( INPUT_GET, 'settings-saved', FILTER_SANITIZE_STRING );
+				$setting_save   = filter_input( INPUT_GET, 'settings-saved', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				if ( ! isset( $setting_save ) ) {
 					$settings_saved = '&settings-saved=true';
 				}

--- a/app/helper/RTMediaSupport.php
+++ b/app/helper/RTMediaSupport.php
@@ -51,14 +51,14 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 			}
 
 			$this->curr_sub_tab = 'support';
-			$tab                = filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING );
+			$tab                = filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( isset( $tab ) ) {
 				$this->curr_sub_tab = $tab;
 			}
 
 			// Check if download debug info request is made or not.
-			$nonce = filter_input( INPUT_POST, 'download_debuginfo_wpnonce', FILTER_SANITIZE_STRING );
-			$info  = filter_input( INPUT_POST, 'download_debuginfo', FILTER_SANITIZE_STRING );
+			$nonce = filter_input( INPUT_POST, 'download_debuginfo_wpnonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+			$info  = filter_input( INPUT_POST, 'download_debuginfo', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 			if ( isset( $info ) && '1' === $info && is_admin() ) {
 				if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'rtmedia-download-debuginfo' ) ) {
@@ -180,7 +180,7 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 		 */
 		public function service_selector() {
 			// todo: nonce required.
-			$form = filter_input( INPUT_POST, 'form', FILTER_SANITIZE_STRING );
+			$form = filter_input( INPUT_POST, 'form', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 			include RTMEDIA_PATH . 'app/helper/templates/service-sector.php';
 		}
@@ -195,7 +195,7 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 		 * @return void
 		 */
 		public function call_get_form( $page = '' ) {
-			$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+			$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( isset( $page ) && 'rtmedia-support' === $page ) {
 				if ( 'support' === $this->curr_sub_tab ) {
 					echo "<div id='rtmedia_service_contact_container' class='rtm-support-container'><form name='rtmedia_service_contact_detail' method='post'>";
@@ -413,7 +413,7 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 		public function get_form( $form = '' ) {
 			// todo: nonce required.
 			if ( empty( $form ) ) {
-				$form = filter_input( INPUT_POST, 'form' . FILTER_SANITIZE_STRING );
+				$form = filter_input( INPUT_POST, 'form' . FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 				$form = isset( $form ) ? $form : 'premium_support';
 			}
 			$meta_title = '';
@@ -449,12 +449,12 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 					echo wp_kses( $content, RTMedia::expanded_allowed_tags() );
 				} else {
 					$website         = filter_input( INPUT_POST, 'website', FILTER_SANITIZE_URL );
-					$subject         = filter_input( INPUT_POST, 'subject', FILTER_SANITIZE_STRING );
-					$details         = filter_input( INPUT_POST, 'details', FILTER_SANITIZE_STRING );
+					$subject         = filter_input( INPUT_POST, 'subject', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+					$details         = filter_input( INPUT_POST, 'details', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 					$server_addr     = rtm_get_server_var( 'SERVER_ADDR', 'FILTER_VALIDATE_IP' );
 					$remote_addr     = rtm_get_server_var( 'REMOTE_ADDR', 'FILTER_VALIDATE_IP' );
-					$server_software = rtm_get_server_var( 'SERVER_SOFTWARE', 'FILTER_SANITIZE_STRING' );
-					$http_user_agent = rtm_get_server_var( 'HTTP_USER_AGENT', 'FILTER_SANITIZE_STRING' );
+					$server_software = rtm_get_server_var( 'SERVER_SOFTWARE', 'FILTER_SANITIZE_FULL_SPECIAL_CHARS' );
+					$http_user_agent = rtm_get_server_var( 'HTTP_USER_AGENT', 'FILTER_SANITIZE_FULL_SPECIAL_CHARS' );
 
 					include RTMEDIA_PATH . 'app/helper/templates/support-form.php';
 				}
@@ -467,7 +467,7 @@ if ( ! class_exists( 'RTMediaSupport' ) ) {
 		 * @return void
 		 */
 		public function submit_request() {
-			$nonce = filter_input( INPUT_POST, 'support_wpnonce', FILTER_SANITIZE_STRING );
+			$nonce = filter_input( INPUT_POST, 'support_wpnonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'rtmedia-support-request' ) ) {
 
 				wp_die(

--- a/app/importers/RTMediaActivityUpgrade.php
+++ b/app/importers/RTMediaActivityUpgrade.php
@@ -79,7 +79,7 @@ class RTMediaActivityUpgrade {
 		}
 
 		rtmedia_update_site_option( 'rtmedia_media_activity_upgrade_pending', $pending );
-		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( $pending > 0 ) {
 			if ( ! ( isset( $page ) && 'rtmedia-activity-upgrade' === $page ) ) {

--- a/app/importers/RTMediaMediaSizeImporter.php
+++ b/app/importers/RTMediaMediaSizeImporter.php
@@ -86,7 +86,7 @@ class RTMediaMediaSizeImporter {
 			return;
 		}
 		if ( $pending > 0 ) {
-			$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+			$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! ( isset( $page ) && 'rtmedia-migration-media-size-import' === $page ) ) {
 				$site_option = get_site_option( 'rtmedia_media_size_import_notice' );
 				if ( ! $site_option || 'hide' !== $site_option ) {

--- a/app/importers/RTMediaMigration.php
+++ b/app/importers/RTMediaMigration.php
@@ -29,8 +29,8 @@ class RTMediaMigration {
 		add_action( 'admin_menu', array( $this, 'menu' ) );
 		add_action( 'wp_ajax_bp_media_rt_db_migration', array( $this, 'migrate_to_new_db' ) );
 
-		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
-		$hide = filter_input( INPUT_GET, 'hide', FILTER_SANITIZE_STRING );
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$hide = filter_input( INPUT_GET, 'hide', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( isset( $page ) && 'rtmedia-migration' === $page && isset( $hide ) && 'true' === $hide ) {
 			$this->hide_migration_notice();
@@ -41,7 +41,7 @@ class RTMediaMigration {
 			return true;
 		}
 
-		$force = filter_input( INPUT_GET, 'force', FILTER_SANITIZE_STRING );
+		$force = filter_input( INPUT_GET, 'force', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		if ( isset( $force ) && 'true' === $force ) {
 			$pending = false;
 		} else {

--- a/app/main/RTMedia.php
+++ b/app/main/RTMedia.php
@@ -1118,8 +1118,8 @@ class RTMedia {
 		$album        = new RTMediaAlbum();
 		$global_album = $album->get_default();
 
-		$action = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) );
-		$mode   = sanitize_text_field( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_STRING ) );
+		$action = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$mode   = sanitize_text_field( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		// Hack for plupload default name.
 		if ( ! empty( $action ) && ! empty( $mode ) && 'file_upload' === $mode ) {

--- a/app/main/contexts/RTMediaContext.php
+++ b/app/main/contexts/RTMediaContext.php
@@ -72,7 +72,7 @@ class RTMediaContext {
 
 			$wp_default_context = array( 'page', 'post' );
 
-			$context = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_STRING ) );
+			$context = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			if ( ! empty( $context ) && in_array( $context, $wp_default_context, true ) ) {
 				$this->type = $context;

--- a/app/main/controllers/activity/RTMediaBuddyPressActivity.php
+++ b/app/main/controllers/activity/RTMediaBuddyPressActivity.php
@@ -479,10 +479,10 @@ class RTMediaBuddyPressActivity {
 		global $rtmedia;
 
 		// Check if this is not a comment.
-		$action = wp_unslash( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) );
+		$action = wp_unslash( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		// When activity upload terms are enabled on activity page, we check whether someone has removed the html element or not.
 		if ( 'post_update' === $action && ! empty( $rtmedia->options['activity_enable_upload_terms'] ) ) {
-			$term = wp_unslash( filter_input( INPUT_POST, 'rtmedia_upload_terms_conditions', FILTER_SANITIZE_STRING ) );
+			$term = wp_unslash( filter_input( INPUT_POST, 'rtmedia_upload_terms_conditions', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			if ( empty( $term ) ) {
 
 				// We set error object in buddypress, so it'll show error on activity page.
@@ -1185,8 +1185,8 @@ class RTMediaBuddyPressActivity {
 					$comment_media    = false;
 					$comment_media_id = false;
 
-					$post_action          = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) );
-					$post_comment_content = sanitize_text_field( filter_input( INPUT_POST, 'comment_content', FILTER_SANITIZE_STRING ) );
+					$post_action          = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+					$post_comment_content = sanitize_text_field( filter_input( INPUT_POST, 'comment_content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 					// if activity is add from comment media.
 					if ( ! empty( $post_comment_content ) || ! empty( $post_action ) ) {
@@ -1196,7 +1196,7 @@ class RTMediaBuddyPressActivity {
 							remove_action( 'bp_activity_content_before_save', 'rtmedia_bp_activity_comment_content_callback', 1001, 1 );
 
 							// comment content.
-							$comment_content = sanitize_text_field( filter_input( INPUT_POST, 'content', FILTER_SANITIZE_STRING ) );
+							$comment_content = sanitize_text_field( filter_input( INPUT_POST, 'content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 						} elseif ( ! empty( $post_comment_content ) ) {
 							// comment content.
 							$comment_content = $post_comment_content;

--- a/app/main/controllers/api/RTMediaJsonApi.php
+++ b/app/main/controllers/api/RTMediaJsonApi.php
@@ -182,7 +182,7 @@ class RTMediaJsonApi {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $this->ec_api_disabled, $this->msg_api_disabled ) );
 		}
 
-		$method = sanitize_text_field( filter_input( INPUT_POST, 'method', FILTER_SANITIZE_STRING ) );
+		$method = sanitize_text_field( filter_input( INPUT_POST, 'method', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		if ( empty( $method ) ) {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $this->ec_method_missing, $this->msg_method_missing ) );
 		}
@@ -191,7 +191,7 @@ class RTMediaJsonApi {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $this->ec_bp_missing, $this->msg_bp_missing ) );
 		}
 		$this->rtmediajsonapifunction = new RTMediaJsonApiFunctions();
-		$token                        = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_STRING ) );
+		$token                        = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $token ) ) {
 			$this->rtmediajsonapifunction->rtmedia_api_verfiy_token();
@@ -275,7 +275,7 @@ class RTMediaJsonApi {
 		}
 
 		$rtmapilogin   = new RTMediaApiLogin();
-		$token         = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_STRING ) );
+		$token         = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		$login_details = array( 'last_access' => current_time( 'mysql' ) );
 
 		if ( ! empty( $token ) ) {
@@ -314,8 +314,8 @@ class RTMediaJsonApi {
 
 		$ec_login_success  = 200004;
 		$msg_login_success = esc_html__( 'login success', 'buddypress-media' );
-		$username          = sanitize_text_field( filter_input( INPUT_POST, 'username', FILTER_SANITIZE_STRING ) );
-		$password          = sanitize_text_field( filter_input( INPUT_POST, 'password', FILTER_SANITIZE_STRING ) );
+		$username          = sanitize_text_field( filter_input( INPUT_POST, 'username', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$password          = sanitize_text_field( filter_input( INPUT_POST, 'password', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $username ) || empty( $password ) ) {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_user_pass_missing, $msg_user_pass_missing ) );
@@ -381,23 +381,23 @@ class RTMediaJsonApi {
 
 		$registration_fields = array( 'username', 'email', 'password', 'password_confirm' );
 		// fields empty field_1, field_4.
-		$field_1 = sanitize_text_field( filter_input( INPUT_POST, 'field_1', FILTER_SANITIZE_STRING ) );
+		$field_1 = sanitize_text_field( filter_input( INPUT_POST, 'field_1', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $field_1 ) ) {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_register_fields_missing, $msg_register_fields_missing ) );
 		}
 
 		foreach ( $registration_fields as $field_name ) {
-			$field_signup = sanitize_text_field( filter_input( INPUT_POST, 'signup_' . $field_name, FILTER_SANITIZE_STRING ) );
+			$field_signup = sanitize_text_field( filter_input( INPUT_POST, 'signup_' . $field_name, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			if ( empty( $field_signup ) ) {
 				wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_register_fields_missing, $msg_register_fields_missing ) );
 			}
 		}
 
 		$signup_email            = filter_input( INPUT_POST, 'signup_email', FILTER_VALIDATE_EMAIL );
-		$signup_username         = sanitize_text_field( filter_input( INPUT_POST, 'signup_username', FILTER_SANITIZE_STRING ) );
-		$signup_password         = sanitize_text_field( filter_input( INPUT_POST, 'signup_password', FILTER_SANITIZE_STRING ) );
-		$signup_password_confirm = sanitize_text_field( filter_input( INPUT_POST, 'signup_password_confirm', FILTER_SANITIZE_STRING ) );
+		$signup_username         = sanitize_text_field( filter_input( INPUT_POST, 'signup_username', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$signup_password         = sanitize_text_field( filter_input( INPUT_POST, 'signup_password', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$signup_password_confirm = sanitize_text_field( filter_input( INPUT_POST, 'signup_password_confirm', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		// incorrect email.
 		if ( ! is_email( $signup_email ) ) {
@@ -445,7 +445,7 @@ class RTMediaJsonApi {
 
 		$ec_email_sent  = 500003;
 		$msg_email_sent = esc_html__( 'reset link sent', 'buddypress-media' );
-		$user_login     = sanitize_text_field( filter_input( INPUT_POST, 'user_login', FILTER_SANITIZE_STRING ) );
+		$user_login     = sanitize_text_field( filter_input( INPUT_POST, 'user_login', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $user_login ) ) {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_email_missing, $msg_email_missing ) );
@@ -543,7 +543,7 @@ class RTMediaJsonApi {
 		$ec_comment_posted  = 800002;
 		$msg_comment_posted = esc_html__( 'comment posted', 'buddypress-media' );
 
-		$content = sanitize_text_field( filter_input( INPUT_POST, 'content', FILTER_SANITIZE_STRING ) );
+		$content = sanitize_text_field( filter_input( INPUT_POST, 'content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $content ) ) {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_comment_content_missing, $msg_comment_content_missing ) );
@@ -1032,8 +1032,8 @@ class RTMediaJsonApi {
 			$field_str          = 'field_';
 			$field_str         .= $i;
 			$field_str_privacy  = $field_str . '_privacy';
-			$$field_str         = sanitize_text_field( filter_input( INPUT_POST, $field_str, FILTER_SANITIZE_STRING ) );
-			$$field_str_privacy = sanitize_text_field( filter_input( INPUT_POST, $field_str_privacy, FILTER_SANITIZE_STRING ) );
+			$$field_str         = sanitize_text_field( filter_input( INPUT_POST, $field_str, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$$field_str_privacy = sanitize_text_field( filter_input( INPUT_POST, $field_str_privacy, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			! empty( $$field_str ) ? $$field_str : '';
 			! empty( $$field_str_privacy ) ? $$field_str_privacy : 'public';
 			if ( 1 === $i || 4 === $i ) {
@@ -1100,10 +1100,10 @@ class RTMediaJsonApi {
 		$ec_look_updated  = 140004;
 		$msg_look_updated = esc_html__( 'media updated', 'buddypress-media' );
 
-		$rtmedia_file = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_file', FILTER_SANITIZE_STRING ) );
-		$image_type   = sanitize_text_field( filter_input( INPUT_POST, 'image_type', FILTER_SANITIZE_STRING ) );
-		$title        = sanitize_text_field( filter_input( INPUT_POST, 'title', FILTER_SANITIZE_STRING ) );
-		$description  = sanitize_text_field( filter_input( INPUT_POST, 'description', FILTER_SANITIZE_STRING ) );
+		$rtmedia_file = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_file', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$image_type   = sanitize_text_field( filter_input( INPUT_POST, 'image_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$title        = sanitize_text_field( filter_input( INPUT_POST, 'title', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$description  = sanitize_text_field( filter_input( INPUT_POST, 'description', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		$updated       = false;
 		$uploaded_look = false;
@@ -1167,9 +1167,9 @@ class RTMediaJsonApi {
 
 			$album_id   = filter_input( INPUT_POST, 'album_id', FILTER_SANITIZE_NUMBER_INT );
 			$context_id = filter_input( INPUT_POST, 'context_id', FILTER_SANITIZE_NUMBER_INT );
-			$context    = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_STRING ) );
-			$privacy    = sanitize_text_field( filter_input( INPUT_POST, 'privacy', FILTER_SANITIZE_STRING ) );
-			$tags       = sanitize_text_field( filter_input( INPUT_POST, 'tags', FILTER_SANITIZE_STRING ) );
+			$context    = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$privacy    = sanitize_text_field( filter_input( INPUT_POST, 'privacy', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$tags       = sanitize_text_field( filter_input( INPUT_POST, 'tags', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			$uploaded['rtmedia_upload_nonce']       = wp_create_nonce( 'rtmedia_upload_nonce' );
 			$uploaded['rtmedia_simple_file_upload'] = 1;
@@ -1271,7 +1271,7 @@ class RTMediaJsonApi {
 		$media_type[]    = 'album';
 		$allowed_types[] = 'album';
 
-		$media_type_temp  = sanitize_text_field( filter_input( INPUT_POST, 'media_type', FILTER_SANITIZE_STRING ) );
+		$media_type_temp  = sanitize_text_field( filter_input( INPUT_POST, 'media_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		$media_type_array = filter_input( INPUT_POST, 'media_type', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
 
 		if ( ! empty( $media_type_temp ) ) {
@@ -1291,7 +1291,7 @@ class RTMediaJsonApi {
 		);
 
 		// global.
-		$global = sanitize_text_field( filter_input( INPUT_POST, 'global', FILTER_SANITIZE_STRING ) );
+		$global = sanitize_text_field( filter_input( INPUT_POST, 'global', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		if ( isset( $global ) ) {
 			if ( 'false' === $global ) {
 				$args['context'] = array(
@@ -1302,7 +1302,7 @@ class RTMediaJsonApi {
 		}
 
 		// context.
-		$context = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_STRING ) );
+		$context = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		if ( isset( $context ) ) {
 			$args['context'] = $context;
 		}
@@ -1334,7 +1334,7 @@ class RTMediaJsonApi {
 
 		$page     = sanitize_text_field( filter_input( INPUT_POST, 'page', FILTER_SANITIZE_NUMBER_INT ) );
 		$per_page = sanitize_text_field( filter_input( INPUT_POST, 'per_page', FILTER_SANITIZE_NUMBER_INT ) );
-		$order_by = sanitize_text_field( filter_input( INPUT_POST, 'order_by', FILTER_SANITIZE_STRING ) );
+		$order_by = sanitize_text_field( filter_input( INPUT_POST, 'order_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		$offset = ( ! empty( $page ) ) ? (int) $page : 0;
 
@@ -1435,7 +1435,7 @@ class RTMediaJsonApi {
 	 * @return array
 	 */
 	public function api_new_media_upload_dir( $args ) {
-		$token = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_STRING ) );
+		$token = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $args ) || ! is_array( $args ) || empty( $token ) ) {
 			foreach ( $args as $key => $arg ) {

--- a/app/main/controllers/api/RTMediaJsonApiFunctions.php
+++ b/app/main/controllers/api/RTMediaJsonApiFunctions.php
@@ -133,7 +133,7 @@ class RTMediaJsonApiFunctions {
 	 */
 	public function rtmedia_api_verfiy_token() {
 		$rtmjsonapi = new RTMediaJsonApi();
-		$token      = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_STRING ) );
+		$token      = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $token ) ) {
 			wp_send_json( $rtmjsonapi->rtmedia_api_response_object( 'FALSE', $rtmjsonapi->ec_token_missing, $rtmjsonapi->msg_token_missing ) );

--- a/app/main/controllers/group/RTMediaGroupExtension.php
+++ b/app/main/controllers/group/RTMediaGroupExtension.php
@@ -89,8 +89,8 @@ if ( class_exists( 'BP_Group_Extension' ) ) :// Recommended, to prevent problems
 			 * Add playlist Save functionality
 			 * By: Yahil
 			 */
-			$rt_album_creation_control      = sanitize_text_field( filter_input( INPUT_POST, 'rt_album_creation_control', FILTER_SANITIZE_STRING ) );
-			$rtmp_playlist_creation_control = sanitize_text_field( filter_input( INPUT_POST, 'rtmp_playlist_creation_control', FILTER_SANITIZE_STRING ) );
+			$rt_album_creation_control      = sanitize_text_field( filter_input( INPUT_POST, 'rt_album_creation_control', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$rtmp_playlist_creation_control = sanitize_text_field( filter_input( INPUT_POST, 'rtmp_playlist_creation_control', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			/**
 			 * Save details 'ALBUM CREATION CONTROL' and 'PLAYLIST CREATION CONTROL'
@@ -143,7 +143,7 @@ if ( class_exists( 'BP_Group_Extension' ) ) :// Recommended, to prevent problems
 		public function edit_screen_save( $group_id = null ) {
 			global $bp;
 
-			$is_save = sanitize_text_field( filter_input( INPUT_POST, 'save', FILTER_SANITIZE_STRING, FILTER_FLAG_EMPTY_STRING_NULL ) );
+			$is_save = sanitize_text_field( filter_input( INPUT_POST, 'save', FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_FLAG_EMPTY_STRING_NULL ) );
 
 			/**
 			 * Updated the following condition
@@ -160,8 +160,8 @@ if ( class_exists( 'BP_Group_Extension' ) ) :// Recommended, to prevent problems
 			 * Add PLAYLIST CREATION CONTROL save functionality
 			 * By: Yahil
 			 */
-			$rt_album_creation_control      = sanitize_text_field( filter_input( INPUT_POST, 'rt_album_creation_control', FILTER_SANITIZE_STRING ) );
-			$rtmp_playlist_creation_control = sanitize_text_field( filter_input( INPUT_POST, 'rtmp_playlist_creation_control', FILTER_SANITIZE_STRING ) );
+			$rt_album_creation_control      = sanitize_text_field( filter_input( INPUT_POST, 'rt_album_creation_control', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$rtmp_playlist_creation_control = sanitize_text_field( filter_input( INPUT_POST, 'rtmp_playlist_creation_control', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			check_admin_referer( 'groups_edit_save_' . $this->slug );
 

--- a/app/main/controllers/media/RTMediaAlbum.php
+++ b/app/main/controllers/media/RTMediaAlbum.php
@@ -107,8 +107,8 @@ class RTMediaAlbum {
 	 */
 	public function verify_nonce( $mode ) {
 
-		$nonce = sanitize_text_field( filter_input( INPUT_POST, "rtmedia_{$mode}_album_nonce", FILTER_SANITIZE_STRING ) );
-		$mode  = sanitize_text_field( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_STRING ) );
+		$nonce = sanitize_text_field( filter_input( INPUT_POST, "rtmedia_{$mode}_album_nonce", FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$mode  = sanitize_text_field( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $mode ) ) {
 			$mode = '';

--- a/app/main/controllers/media/RTMediaFeatured.php
+++ b/app/main/controllers/media/RTMediaFeatured.php
@@ -254,7 +254,7 @@ class RTMediaFeatured extends RTMediaUserInteraction {
 			return;
 		}
 
-		$nonce = sanitize_text_field( filter_input( INPUT_POST, 'featured_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce = sanitize_text_field( filter_input( INPUT_POST, 'featured_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! wp_verify_nonce( $nonce, 'rtm_media_featured_nonce' . $this->media->id ) ) {
 			$return['nonce'] = true;
@@ -288,7 +288,7 @@ class RTMediaFeatured extends RTMediaUserInteraction {
 			$return['error']  = esc_html__( 'Media type is not allowed', 'buddypress-media' );
 		}
 
-		$is_json = sanitize_text_field( filter_input( INPUT_POST, 'json', FILTER_SANITIZE_STRING ) );
+		$is_json = sanitize_text_field( filter_input( INPUT_POST, 'json', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $is_json ) && 'true' === $is_json ) {
 			wp_send_json( $return );

--- a/app/main/controllers/media/RTMediaGroupFeatured.php
+++ b/app/main/controllers/media/RTMediaGroupFeatured.php
@@ -301,7 +301,7 @@ class RTMediaGroupFeatured extends RTMediaUserInteraction {
 			$return['error']  = esc_html__( 'Media type is not allowed', 'buddypress-media' );
 		}
 
-		$is_json = sanitize_text_field( filter_input( INPUT_POST, 'json', FILTER_SANITIZE_STRING ) );
+		$is_json = sanitize_text_field( filter_input( INPUT_POST, 'json', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( isset( $is_json ) && 'true' === $is_json ) {
 			wp_send_json( $return );

--- a/app/main/controllers/media/RTMediaLike.php
+++ b/app/main/controllers/media/RTMediaLike.php
@@ -127,7 +127,7 @@ class RTMediaLike extends RTMediaUserInteraction {
 	public function process() {
 
 		$actions    = $this->model->get( array( 'id' => $this->action_query->id ) );
-		$like_nonce = sanitize_text_field( filter_input( INPUT_POST, 'like_nonce', FILTER_SANITIZE_STRING ) );
+		$like_nonce = sanitize_text_field( filter_input( INPUT_POST, 'like_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! wp_verify_nonce( $like_nonce, 'rtm_media_like_nonce' . $this->media->id ) ) {
 			die();
@@ -213,7 +213,7 @@ class RTMediaLike extends RTMediaUserInteraction {
 		$rtmedia_points_media_id = $this->action_query->id;
 		do_action( 'rtmedia_after_like_media', $this );
 
-		$is_json = sanitize_text_field( filter_input( INPUT_POST, 'json', FILTER_SANITIZE_STRING ) );
+		$is_json = sanitize_text_field( filter_input( INPUT_POST, 'json', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $is_json ) && 'true' === $is_json ) {
 			wp_send_json( $return );

--- a/app/main/controllers/media/RTMediaMedia.php
+++ b/app/main/controllers/media/RTMediaMedia.php
@@ -85,8 +85,8 @@ class RTMediaMedia {
 	 */
 	public function verify_nonce( $mode ) {
 
-		$nonce = sanitize_text_field( filter_input( INPUT_POST, "rtmedia_{$mode}_media_nonce", FILTER_SANITIZE_STRING ) );
-		$mode  = sanitize_text_field( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_STRING ) );
+		$nonce = sanitize_text_field( filter_input( INPUT_POST, "rtmedia_{$mode}_media_nonce", FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$mode  = sanitize_text_field( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $mode ) ) {
 			$mode = '';
@@ -377,7 +377,7 @@ class RTMediaMedia {
 				}
 			}
 
-			$post_comment = sanitize_text_field( filter_input( INPUT_POST, 'comment_id', FILTER_SANITIZE_STRING ) );
+			$post_comment = sanitize_text_field( filter_input( INPUT_POST, 'comment_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			// delete comment if media is in the comment.
 			if ( class_exists( 'RTMediaTemplate' ) && isset( $media[0]->id ) && empty( $post_comment ) ) {

--- a/app/main/controllers/media/RTMediaUserInteraction.php
+++ b/app/main/controllers/media/RTMediaUserInteraction.php
@@ -104,6 +104,55 @@ class RTMediaUserInteraction {
 	public $plural;
 
 	/**
+	 * Whether the action is countable.
+	 *
+	 * @var bool
+	 */
+	public $countable;
+
+	/**
+	 * Whether the action is single.
+	 *
+	 * @var bool
+	 */
+	public $single;
+
+	/**
+	 * Whether the action is repeatable.
+	 *
+	 * @var bool
+	 */
+	public $repeatable;
+
+	/**
+	 * Whether the action is undoable.
+	 *
+	 * @var bool
+	 */
+	public $undoable;
+
+	/**
+	 * Icon class.
+	 *
+	 * @var string
+	 */
+	public $icon_class;
+
+	/**
+	 * Person label.
+	 *
+	 * @var string
+	 */
+	public $person_label;
+
+	/**
+	 * Person plural label.
+	 *
+	 * @var string
+	 */
+	public $person_plural_label;
+
+	/**
 	 * Initialise the user interaction
 	 *
 	 * @param array $args Arguments array.

--- a/app/main/controllers/privacy/RTMediaPrivacy.php
+++ b/app/main/controllers/privacy/RTMediaPrivacy.php
@@ -113,7 +113,7 @@ class RTMediaPrivacy {
 	 */
 	public function rtm_change_activity_privacy() {
 
-		$nonce       = sanitize_text_field( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING ) );
+		$nonce       = sanitize_text_field( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		$privacy     = filter_input( INPUT_POST, 'privacy', FILTER_SANITIZE_NUMBER_INT );
 		$activity_id = filter_input( INPUT_POST, 'activity_id', FILTER_SANITIZE_NUMBER_INT );
 
@@ -463,8 +463,8 @@ class RTMediaPrivacy {
 			return;
 		}
 
-		$default_privacy = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia-default-privacy', FILTER_SANITIZE_STRING ) );
-		$nonce           = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_member_settings_privacy', FILTER_SANITIZE_STRING ) );
+		$default_privacy = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia-default-privacy', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$nonce           = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_member_settings_privacy', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		// Old condition won't work as we've added sanitize_text_field for $default_privacy.
 		// We can't perform empty as 0 could be the possible value, so we check for empty string instead.

--- a/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
+++ b/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
@@ -31,7 +31,7 @@ class RTMediaGalleryShortcode {
 	 * Get template for json response.
 	 */
 	public function ajax_rtmedia_get_template() {
-		$template = sanitize_text_field( filter_input( INPUT_GET, 'template', FILTER_SANITIZE_STRING ) );
+		$template = sanitize_text_field( filter_input( INPUT_GET, 'template', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $template ) ) {
 			$template_url = RTMediaTemplate::locate_template( $template, 'media/', false );

--- a/app/main/controllers/template/RTMediaAJAX.php
+++ b/app/main/controllers/template/RTMediaAJAX.php
@@ -31,14 +31,14 @@ class RTMediaAJAX {
 	 * Create album.
 	 */
 	public function create_album() {
-		$nonce        = sanitize_text_field( filter_input( INPUT_POST, 'create_album_nonce', FILTER_SANITIZE_STRING ) );
-		$_name        = sanitize_text_field( filter_input( INPUT_POST, 'name', FILTER_SANITIZE_STRING ) );
-		$_description = sanitize_text_field( filter_input( INPUT_POST, 'description', FILTER_SANITIZE_STRING ) );
+		$nonce        = sanitize_text_field( filter_input( INPUT_POST, 'create_album_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$_name        = sanitize_text_field( filter_input( INPUT_POST, 'name', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$_description = sanitize_text_field( filter_input( INPUT_POST, 'description', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		$return['error'] = false;
 		if ( wp_verify_nonce( $nonce, 'rtmedia_create_album_nonce' ) && isset( $_name ) && $_name && is_rtmedia_album_enable() ) {
 
-			$_context    = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_STRING ) );
+			$_context    = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			$_context_id = filter_input( INPUT_POST, 'context_id', FILTER_SANITIZE_NUMBER_INT );
 
 			if ( ! empty( $_context ) && 'group' === $_context ) {

--- a/app/main/controllers/template/RTMediaTemplate.php
+++ b/app/main/controllers/template/RTMediaTemplate.php
@@ -344,7 +344,7 @@ class RTMediaTemplate {
 
 		global $rtmedia_query;
 
-		$nonce = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_media_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_media_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( wp_verify_nonce( $nonce, 'rtmedia_' . $rtmedia_query->action_query->id ) ) {
 
@@ -381,7 +381,7 @@ class RTMediaTemplate {
 
 			$state = $media->update( $rtmedia_query->action_query->id, $data, $rtmedia_query->media[0]->media_id );
 
-			$rtmedia_filepath_old = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia-filepath-old', FILTER_SANITIZE_STRING ) );
+			$rtmedia_filepath_old = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia-filepath-old', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			if ( isset( $rtmedia_filepath_old ) ) {
 				$is_valid_url = preg_match( "/\b(?:(?:https?|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/i", $rtmedia_filepath_old );
 
@@ -505,15 +505,15 @@ class RTMediaTemplate {
 	public function save_album_edit() {
 		global $rtmedia_query;
 
-		$nonce = wp_unslash( filter_input( INPUT_POST, 'rtmedia_media_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce = wp_unslash( filter_input( INPUT_POST, 'rtmedia_media_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( wp_verify_nonce( $nonce, 'rtmedia_' . $rtmedia_query->media_query['album_id'] ) ) {
 			$media = new RTMediaMedia();
 			$model = new RTMediaModel();
 
-			$submit         = sanitize_text_field( filter_input( INPUT_POST, 'submit', FILTER_SANITIZE_STRING ) );
-			$_move_selected = sanitize_text_field( filter_input( INPUT_POST, 'move-selected', FILTER_SANITIZE_STRING ) );
-			$_album         = sanitize_text_field( filter_input( INPUT_POST, 'album', FILTER_SANITIZE_STRING ) );
+			$submit         = sanitize_text_field( filter_input( INPUT_POST, 'submit', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$_move_selected = sanitize_text_field( filter_input( INPUT_POST, 'move-selected', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$_album         = sanitize_text_field( filter_input( INPUT_POST, 'album', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			$filters = array(
 				'selected' => array(
@@ -615,7 +615,7 @@ class RTMediaTemplate {
 	 * Delete multiple mmedia.
 	 */
 	public function bulk_delete() {
-		$nonce            = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_bulk_delete_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce            = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_bulk_delete_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		$_wp_http_referer = filter_input( INPUT_POST, '_wp_http_referer', FILTER_SANITIZE_URL );
 		$media            = new RTMediaMedia();
 
@@ -647,7 +647,7 @@ class RTMediaTemplate {
 	public function single_delete() {
 		global $rtmedia_query;
 
-		$nonce = wp_unslash( filter_input( INPUT_POST, 'rtmedia_media_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce = wp_unslash( filter_input( INPUT_POST, 'rtmedia_media_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( wp_verify_nonce( $nonce, 'rtmedia_' . $rtmedia_query->media[0]->id ) ) {
 			$id = $_POST;
@@ -698,7 +698,7 @@ class RTMediaTemplate {
 	public function album_delete() {
 		global $rtmedia_query;
 
-		$nonce = wp_unslash( filter_input( INPUT_POST, 'rtmedia_delete_album_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce = wp_unslash( filter_input( INPUT_POST, 'rtmedia_delete_album_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( wp_verify_nonce( $nonce, 'rtmedia_delete_album_' . $rtmedia_query->media_query['album_id'] ) ) {
 			$media          = new RTMediaMedia();
@@ -735,7 +735,7 @@ class RTMediaTemplate {
 			return;
 		}
 
-		$nonce    = wp_unslash( filter_input( INPUT_POST, 'rtmedia_merge_album_nonce', FILTER_SANITIZE_STRING ) );
+		$nonce    = wp_unslash( filter_input( INPUT_POST, 'rtmedia_merge_album_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 		$album_id = filter_input( INPUT_POST, 'album', FILTER_VALIDATE_INT );
 
 		if ( wp_verify_nonce( $nonce, 'rtmedia_merge_album_' . $rtmedia_query->media_query['album_id'] ) ) {
@@ -785,8 +785,8 @@ class RTMediaTemplate {
 			 * /media/comments [POST]
 			 * Post a comment to the album by post id
 			 */
-			$nonce           = wp_unslash( filter_input( INPUT_POST, 'rtmedia_comment_nonce', FILTER_SANITIZE_STRING ) );
-			$comment_content = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'comment_content', FILTER_SANITIZE_STRING ) ) );
+			$nonce           = wp_unslash( filter_input( INPUT_POST, 'rtmedia_comment_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$comment_content = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'comment_content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 
 			if ( wp_verify_nonce( $nonce, 'rtmedia_comment_nonce' ) ) {
 				$comment_activity_id = false;
@@ -897,7 +897,7 @@ class RTMediaTemplate {
 						);
 					}
 				}
-				$_rt_ajax = sanitize_text_field( filter_input( INPUT_POST, 'rtajax', FILTER_SANITIZE_STRING ) );
+				$_rt_ajax = sanitize_text_field( filter_input( INPUT_POST, 'rtajax', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 				if ( ! empty( $_rt_ajax ) ) {
 					global $wpdb;

--- a/app/main/controllers/template/rtmedia-actions.php
+++ b/app/main/controllers/template/rtmedia-actions.php
@@ -714,7 +714,7 @@ function rt_check_addon_status() {
 			if ( ! empty( $addon_data ) && is_object( $addon_data ) && empty( $addon['args']['license_key'] ) ) {
 				if ( isset( $addon_data->success ) && isset( $addon_data->license ) ) {
 
-					$activate_addon = sanitize_text_field( filter_input( INPUT_POST, 'edd_' . $addon_id . '_license_key', FILTER_SANITIZE_STRING ) );
+					$activate_addon = sanitize_text_field( filter_input( INPUT_POST, 'edd_' . $addon_id . '_license_key', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 					if ( ( isset( $activate_addon ) && '' === $activate_addon ) || '' === $addon_data->success || 'invalid' === $addon_data->license ) {
 						delete_option( 'edd_' . $addon_id . '_license_status' );
@@ -777,7 +777,7 @@ function rt_check_addon_status() {
 				}
 			}
 
-			$activate = sanitize_text_field( filter_input( INPUT_POST, 'edd_' . $addon_id . '_license_activate', FILTER_SANITIZE_STRING ) );
+			$activate = sanitize_text_field( filter_input( INPUT_POST, 'edd_' . $addon_id . '_license_activate', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 			// Listen for activate button to be clicked.
 			// Also check if information about the addon in already fetched from the store.
@@ -884,10 +884,10 @@ function add_search_filter( $attr = null ) {
 			return;
 		}
 
-		$search_value = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'search', FILTER_SANITIZE_STRING ) ) );
+		$search_value = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 
 		if ( empty( $search_by ) ) {
-			$search_value = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_STRING ) ) );
+			$search_value = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 		}
 
 		$html  = "<form method='post' id='media_search_form' class='media_search'>";
@@ -933,7 +933,7 @@ function add_search_filter( $attr = null ) {
 				unset( $search_by['author'] );
 			}
 
-			$search_by_var = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'search_by', FILTER_SANITIZE_STRING ) ) );
+			$search_by_var = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'search_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 
 			foreach ( $search_by as $key => $value ) {
 				$selected = ( isset( $search_by_var ) && $search_by_var === $key ? 'selected' : '' );
@@ -1011,8 +1011,8 @@ function rtmedia_gallery_shortcode_json_query_vars( $wp_query ) {
 		$pagename = explode( '/', $wp_query->query_vars['pagename'] );
 	}
 
-	$is_json              = sanitize_text_field( filter_input( INPUT_GET, 'json', FILTER_SANITIZE_STRING ) );
-	$is_rtmedia_shortcode = sanitize_text_field( filter_input( INPUT_GET, 'rtmedia_shortcode', FILTER_SANITIZE_STRING ) );
+	$is_json              = sanitize_text_field( filter_input( INPUT_GET, 'json', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+	$is_rtmedia_shortcode = sanitize_text_field( filter_input( INPUT_GET, 'rtmedia_shortcode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	if ( ! empty( $pagename ) && ! empty( $is_json ) && 'true' === $is_json && ! empty( $is_rtmedia_shortcode ) && 'true' === $is_rtmedia_shortcode ) {
 		$pagename                         = $pagename[0];

--- a/app/main/controllers/template/rtmedia-ajax-actions.php
+++ b/app/main/controllers/template/rtmedia-ajax-actions.php
@@ -11,8 +11,8 @@
  */
 function rtmedia_delete_uploaded_media() {
 
-	$action   = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) );
-	$nonce    = sanitize_text_field( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING ) );
+	$action   = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+	$nonce    = sanitize_text_field( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 	$media_id = filter_input( INPUT_POST, 'media_id', FILTER_SANITIZE_NUMBER_INT );
 
 	if ( ! empty( $action ) && 'delete_uploaded_media' === $action && ! empty( $media_id ) ) {

--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -179,10 +179,10 @@ add_filter( 'rtm_main_template_buddypress_enable', 'rtm_is_buddypress_enable', 1
  * @return bool
  */
 function rtmedia_media_gallery_show_title_template_request( $flag ) {
-	$media_title = sanitize_text_field( filter_input( INPUT_POST, 'media_title', FILTER_SANITIZE_STRING ) );
+	$media_title = sanitize_text_field( filter_input( INPUT_POST, 'media_title', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	if ( empty( $media_title ) ) {
-		$media_title = sanitize_text_field( filter_input( INPUT_GET, 'media_title', FILTER_SANITIZE_STRING ) );
+		$media_title = sanitize_text_field( filter_input( INPUT_GET, 'media_title', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 	}
 
 	if ( ! empty( $media_title ) && 'false' === $media_title ) {
@@ -203,10 +203,10 @@ add_filter( 'rtmedia_media_gallery_show_media_title', 'rtmedia_media_gallery_sho
  */
 function rtmedia_media_gallery_lightbox_template_request( $class ) {
 
-	$lightbox = sanitize_text_field( filter_input( INPUT_POST, 'lightbox', FILTER_SANITIZE_STRING ) );
+	$lightbox = sanitize_text_field( filter_input( INPUT_POST, 'lightbox', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	if ( empty( $lightbox ) ) {
-		$lightbox = sanitize_text_field( filter_input( INPUT_GET, 'lightbox', FILTER_SANITIZE_STRING ) );
+		$lightbox = sanitize_text_field( filter_input( INPUT_GET, 'lightbox', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 	}
 
 	if ( ! empty( $lightbox ) && 'false' === $lightbox ) {
@@ -618,8 +618,8 @@ function rtmedia_edit_media_on_database( $data, $post_ID ) {
 	$post = get_post( $post_ID );
 
 	$postid  = filter_input( INPUT_POST, 'postid', FILTER_VALIDATE_INT );
-	$action  = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) );
-	$context = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_STRING ) );
+	$action  = sanitize_text_field( filter_input( INPUT_POST, 'action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+	$context = sanitize_text_field( filter_input( INPUT_POST, 'context', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	// @todo need to check why 'context' key is not set in POST when user clicks on scale button on edit image.
 	if ( ! empty( $postid ) && 'image-editor' === $action && ! empty( $context ) && 'edit-attachment' === $context ) {
@@ -758,10 +758,10 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 
 	if ( function_exists( 'rtmedia_media_search_enabled' ) && rtmedia_media_search_enabled() ) {
 
-		$search                = sanitize_text_field( urldecode( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_STRING ) ) ) );
-		$search_by             = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_STRING ) ) );
-		$media_type            = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'media_type', FILTER_SANITIZE_STRING ) ) );
-		$rtmedia_current_album = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'rtmedia-current-album', FILTER_SANITIZE_STRING ) ) );
+		$search                = sanitize_text_field( urldecode( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) ) );
+		$search_by             = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+		$media_type            = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'media_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+		$rtmedia_current_album = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'rtmedia-current-album', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 
 		if ( '' !== $search ) {
 			$author_id   = rtm_select_user( $search );
@@ -860,9 +860,9 @@ function rtmedia_search_fillter_join_query( $join, $table_name ) {
 		$terms_table              = $wpdb->terms;
 		$term_relationships_table = $wpdb->term_relationships;
 		$term_taxonomy_table      = $wpdb->term_taxonomy;
-		$search                   = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_STRING ) ) );
-		$search_by                = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_STRING ) ) );
-		$media_type               = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'media_type', FILTER_SANITIZE_STRING ) ) );
+		$search                   = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+		$search_by                = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+		$media_type               = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'media_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 
 		if ( 'album' === $media_type ) {
 			$media_type = 'rtmedia_album';
@@ -895,8 +895,8 @@ add_filter( 'rtmedia-model-join-query', 'rtmedia_search_fillter_join_query', 11,
  * @return array
  */
 function rtmedia_model_query_columns( $columns ) {
-	$search    = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_STRING ) ) );
-	$search_by = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_STRING ) ) );
+	$search    = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+	$search_by = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 
 	if ( ! empty( $search ) ) {
 		if ( ! empty( $search_by ) && 'media_type' === $search_by ) {

--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -1686,10 +1686,10 @@ function rtmedia_pagination_page_link( $page_no = '' ) {
 	$rtm_attr           = get_query_var( 'rtm_attr' );
 	$rtm_term           = get_query_var( 'rtm_term' );
 
-	$is_on_home           = sanitize_text_field( filter_input( INPUT_GET, 'is_on_home', FILTER_SANITIZE_STRING ) );
-	$is_rtmedia_shortcode = sanitize_text_field( filter_input( INPUT_GET, 'rtmedia_shortcode', FILTER_SANITIZE_STRING ) );
+	$is_on_home           = sanitize_text_field( filter_input( INPUT_GET, 'is_on_home', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+	$is_rtmedia_shortcode = sanitize_text_field( filter_input( INPUT_GET, 'rtmedia_shortcode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 	$context_id           = filter_input( INPUT_GET, 'context_id', FILTER_VALIDATE_INT );
-	$context              = sanitize_text_field( filter_input( INPUT_GET, 'context', FILTER_SANITIZE_STRING ) );
+	$context              = sanitize_text_field( filter_input( INPUT_GET, 'context', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 	// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	if ( ! empty( $context ) && in_array( $context, $wp_default_context, true ) && ! empty( $is_rtmedia_shortcode ) && 'true' === $is_rtmedia_shortcode ) {
@@ -3920,7 +3920,7 @@ function rtmedia_add_multiple_meta( $media_id, $meta_key_val ) {
  *
  * @return string
  */
-function rtm_get_server_var( $server_key, $filter_type = 'FILTER_SANITIZE_STRING' ) {
+function rtm_get_server_var( $server_key, $filter_type = 'FILTER_SANITIZE_FULL_SPECIAL_CHARS' ) {
 
 	$server_val = '';
 
@@ -4158,12 +4158,12 @@ function rtmedia_get_original_comment_media_content() {
 	$old_content = '&nbsp;';
 
 	// get the original content from the POST.
-	$content = sanitize_text_field( filter_input( INPUT_POST, 'content', FILTER_SANITIZE_STRING ) );
+	$content = sanitize_text_field( filter_input( INPUT_POST, 'content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 	if ( ! empty( $content ) ) {
 		$old_content = $content;
 	}
 
-	$comment = sanitize_text_field( filter_input( INPUT_POST, 'comment_content', FILTER_SANITIZE_STRING ) );
+	$comment = sanitize_text_field( filter_input( INPUT_POST, 'comment_content', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 	if ( ! empty( $comment ) ) {
 		$old_content = $comment;
 	}
@@ -4346,9 +4346,9 @@ if ( ! function_exists( 'rtmedia_show_title' ) ) {
 
 		if ( ! empty( $rtmedia_backbone['backbone'] ) ) {
 
-			$media_title = sanitize_text_field( filter_input( INPUT_POST, 'media_title', FILTER_SANITIZE_STRING ) );
+			$media_title = sanitize_text_field( filter_input( INPUT_POST, 'media_title', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			if ( empty( $media_title ) ) {
-				$media_title = sanitize_text_field( filter_input( INPUT_GET, 'media_title', FILTER_SANITIZE_STRING ) );
+				$media_title = sanitize_text_field( filter_input( INPUT_GET, 'media_title', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 			}
 			if ( empty( $media_title ) || 'false' === $media_title ) {
 				return 'hide';

--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -2827,6 +2827,8 @@ function rtmedia_edit_media_privacy_ui() {
 			}
 		}
 	}
+
+	return false;
 }
 
 /**

--- a/app/main/controllers/upload/RTMediaUploadEndpoint.php
+++ b/app/main/controllers/upload/RTMediaUploadEndpoint.php
@@ -39,10 +39,10 @@ class RTMediaUploadEndpoint {
 			include get_404_template();
 		} else {
 
-			$nonce         = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'rtmedia_upload_nonce', FILTER_SANITIZE_STRING ) ) );
-			$mode          = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_STRING ) ) );
-			$_redirection  = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'redirection', FILTER_SANITIZE_STRING ) ) );
-			$_redirect     = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'redirect', FILTER_SANITIZE_STRING ) ) );
+			$nonce         = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'rtmedia_upload_nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+			$mode          = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'mode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+			$_redirection  = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'redirection', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
+			$_redirect     = sanitize_text_field( wp_unslash( filter_input( INPUT_POST, 'redirect', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 			$_activity_id  = filter_input( INPUT_POST, 'activity_id', FILTER_VALIDATE_INT );
 			$_redirect_url = filter_input( INPUT_POST, 'redirect', FILTER_SANITIZE_NUMBER_INT );
 
@@ -52,9 +52,9 @@ class RTMediaUploadEndpoint {
 			if ( ! empty( $rtmedia->options['activity_enable_upload_terms'] ) ) {
 
 				// When media comment is uploaded, comment_media_activity_id will be there, so we check if it's not there.
-				$activity_request = wp_unslash( filter_input( INPUT_POST, 'activity_terms_condition_request', FILTER_SANITIZE_STRING ) );
+				$activity_request = wp_unslash( filter_input( INPUT_POST, 'activity_terms_condition_request', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 				if ( ! empty( $activity_request ) ) {
-					$terms_condition = wp_unslash( filter_input( INPUT_POST, 'activity_terms_condition', FILTER_SANITIZE_STRING ) );
+					$terms_condition = wp_unslash( filter_input( INPUT_POST, 'activity_terms_condition', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 					if ( empty( $terms_condition ) ) {
 						// This will be uploaded by JavaScript only so we send json response.
 						wp_send_json_error( esc_html__( 'Terms and Conditions checkbox not found!', 'buddypress-media' ) );
@@ -65,10 +65,10 @@ class RTMediaUploadEndpoint {
 			// When activity upload terms are enabled on media upload page, we check whether someone has removed the html element or not.
 			if ( ! empty( $rtmedia->options['general_enable_upload_terms'] ) ) {
 
-				$uploader_request = wp_unslash( filter_input( INPUT_POST, 'uploader_terms_condition_request', FILTER_SANITIZE_STRING ) );
+				$uploader_request = wp_unslash( filter_input( INPUT_POST, 'uploader_terms_condition_request', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 				// We check for all other contexts, group and profile is checked above.
 				if ( ! empty( $uploader_request ) ) {
-					$terms_condition = wp_unslash( filter_input( INPUT_POST, 'uploader_terms_condition', FILTER_SANITIZE_STRING ) );
+					$terms_condition = wp_unslash( filter_input( INPUT_POST, 'uploader_terms_condition', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 					if ( empty( $terms_condition ) ) {
 						// This will be uploaded by JavaScript only so we send json response.
 						wp_send_json_error( esc_html__( 'Terms and Conditions checkbox not found!', 'buddypress-media' ) );
@@ -248,7 +248,7 @@ class RTMediaUploadEndpoint {
 						// Following will not apply to activity uploads. For first time activity won't be generated.
 						// Create activity first and pass activity id in response.
 						// todo rtmedia_media_single_activity filter. It will create 2 activity with same media if uploaded from activity page.
-						$_rtmedia_update = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_update', FILTER_SANITIZE_STRING ) );
+						$_rtmedia_update = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_update', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 						if ( ( -1 === intval( $activity_id ) && ( ! ( isset( $_rtmedia_update ) && 'true' === $_rtmedia_update ) ) ) || $allow_single_activity ) {
 							$activity_id = $media_obj->insert_activity( $media[0]->media_id, $media[0] );
@@ -350,8 +350,8 @@ class RTMediaUploadEndpoint {
 			// Ha ha ha.
 			ob_end_clean();
 			// check for simple.
-			$rtmedia_update = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_update', FILTER_SANITIZE_STRING ) );
-			$_user_agent    = rtm_get_server_var( 'HTTP_USER_AGENT', 'FILTER_SANITIZE_STRING' );
+			$rtmedia_update = sanitize_text_field( filter_input( INPUT_POST, 'rtmedia_update', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+			$_user_agent    = rtm_get_server_var( 'HTTP_USER_AGENT', 'FILTER_SANITIZE_FULL_SPECIAL_CHARS' );
 
 			/**
 			 * If(redirect)

--- a/app/main/controllers/upload/RTMediaUploadView.php
+++ b/app/main/controllers/upload/RTMediaUploadView.php
@@ -284,7 +284,7 @@ class RTMediaUploadView {
 		$tabs          = apply_filters( 'rtmedia_upload_tabs', $tabs );
 
 		$attr = $this->attributes;
-		$mode = sanitize_text_field( filter_input( INPUT_GET, 'mode', FILTER_SANITIZE_STRING ) );
+		$mode = sanitize_text_field( filter_input( INPUT_GET, 'mode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( is_null( $mode ) || false === $mode || ! array_key_exists( $mode, $tabs ) ) {
 			$mode = 'file_upload';

--- a/app/main/routers/RTMediaRouter.php
+++ b/app/main/routers/RTMediaRouter.php
@@ -149,7 +149,7 @@ class RTMediaRouter {
 		global $rt_ajax_request;
 		$rt_ajax_request = false;
 
-		$req_with = rtm_get_server_var( 'HTTP_X_REQUESTED_WITH', 'FILTER_SANITIZE_STRING' );
+		$req_with = rtm_get_server_var( 'HTTP_X_REQUESTED_WITH', 'FILTER_SANITIZE_FULL_SPECIAL_CHARS' );
 
 		// check if it is an ajax request.
 		if (

--- a/app/main/routers/query/RTMediaQuery.php
+++ b/app/main/routers/query/RTMediaQuery.php
@@ -116,6 +116,20 @@ class RTMediaQuery {
 	public $friendship;
 
 	/**
+	 * Flag to check if the query is for upload shortcode
+	 *
+	 * @var bool
+	 */
+	public $is_upload_shortcode;
+
+	/**
+	 * Store the current media object like as we WordPress store the current post object in loop.
+	 *
+	 * @var bool
+	 */
+	public $rtmedia;
+
+	/**
 	 * Initialise the query
 	 *
 	 * @param array|bool $args The query arguments.

--- a/app/main/routers/query/RTMediaQuery.php
+++ b/app/main/routers/query/RTMediaQuery.php
@@ -130,6 +130,20 @@ class RTMediaQuery {
 	public $rtmedia;
 
 	/**
+	 * Store the album object, if the query is for album media.
+	 *
+	 * @var mixed
+	 */
+	public $album;
+
+	/**
+	 * Query vars.
+	 *
+	 * @var mixed
+	 */
+	public $query_vars;
+
+	/**
 	 * Initialise the query
 	 *
 	 * @param array|bool $args The query arguments.

--- a/app/main/routers/query/RTMediaQuery.php
+++ b/app/main/routers/query/RTMediaQuery.php
@@ -298,7 +298,7 @@ class RTMediaQuery {
 	 */
 	public function set_json_format() {
 
-		$json = sanitize_text_field( filter_input( INPUT_GET, 'json', FILTER_SANITIZE_STRING ) );
+		$json = sanitize_text_field( filter_input( INPUT_GET, 'json', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $json ) ) {
 			$this->format = 'json';
@@ -337,7 +337,7 @@ class RTMediaQuery {
 		$format         = '';
 		$pageno         = 1;
 
-		$json = sanitize_text_field( filter_input( INPUT_GET, 'json', FILTER_SANITIZE_STRING ) );
+		$json = sanitize_text_field( filter_input( INPUT_GET, 'json', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		// Get page number for json response.
 		if ( ! empty( $json ) ) {
@@ -376,7 +376,7 @@ class RTMediaQuery {
 
 				$modifier_type = 'id';
 
-				$request_action = sanitize_text_field( filter_input( INPUT_POST, 'request_action', FILTER_SANITIZE_STRING ) );
+				$request_action = sanitize_text_field( filter_input( INPUT_POST, 'request_action', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 				// this block is unnecessary, please delete, asap.
 				if ( 'delete' === $request_action ) {
 
@@ -575,7 +575,7 @@ class RTMediaQuery {
 			)
 		);
 
-		$rtmedia_shortcode = sanitize_text_field( filter_input( INPUT_GET, 'rtmedia_shortcode', FILTER_SANITIZE_STRING ) );
+		$rtmedia_shortcode = sanitize_text_field( filter_input( INPUT_GET, 'rtmedia_shortcode', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( ! empty( $rtmedia_shortcode ) ) {
 			$query_data = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification

--- a/lib/deactivation-survey/deactivation-survey.php
+++ b/lib/deactivation-survey/deactivation-survey.php
@@ -77,7 +77,7 @@ class Deactivation_Survey {
 
         // Filter the inputs.
         $site_url = filter_input( INPUT_POST, 'site_url', FILTER_SANITIZE_URL );
-        $reason   = filter_input( INPUT_POST, 'reason', FILTER_SANITIZE_STRING );
+        $reason   = filter_input( INPUT_POST, 'reason', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
         $user     = filter_input( INPUT_POST, 'user', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
 
         $data = [

--- a/templates/main.php
+++ b/templates/main.php
@@ -16,7 +16,7 @@ $rt_ajax_request = false;
 
 // Todo sanitize and fix $_SERVER variable usage.
 // Check if it is an ajax request.
-$_rt_ajax_request = rtm_get_server_var( 'HTTP_X_REQUESTED_WITH', 'FILTER_SANITIZE_STRING' );
+$_rt_ajax_request = rtm_get_server_var( 'HTTP_X_REQUESTED_WITH', 'FILTER_SANITIZE_FULL_SPECIAL_CHARS' );
 if ( 'xmlhttprequest' === strtolower( $_rt_ajax_request ) ) {
 	$rt_ajax_request = true;
 }


### PR DESCRIPTION
# Fix PHP deprecated notices

## These `PHP` deprecated notices are resolved

### `FILTER_SANITIZE_STRING` filter deprecated
- `FILTER_SANITIZE_STRING` is deprecated in the latest PHP versions.
- According to PHP docs, It is solved by replacing `FILTER_SANITIZE_STRING` to `FILTER_SANITIZE_FULL_SPECIAL_CHARS`.

### Dynamic property creation is not allowed
- This error occurs if we use a class data member without declaring it in class.
	```PHP
	class Some_Class {
		public function __constructure () {
			// In the below line, we get an error in the latest version of PHP because we didn't declare the data member `$some_var` in class.
		$this->some_var = 123;
		}

	/**
	 * It can be fixed by declaring data members in the class.
	 */
	class Some_Class {
		public $some_var;

		public function __constructure ()
			$this->some_var = 123;
		}
	}
	```
- It is produced by the `RTMediaUserInteraction` class, where strings are passed as args and are used to create class properties dynamically.
- It is solved by adding those properties to the `RTMediaUserInteraction` class.

## Note
- These changes are support for 7.0 and later versions of PHP.

## Related Issue
- #1987 