### PR TITLE
Fix the plugin deactivation survey issue

### DIFF
--- a/lib/deactivation-survey/deactivation-survey.js
+++ b/lib/deactivation-survey/deactivation-survey.js
@@ -56,6 +56,8 @@ jQuery( document ).ready( function ( $ ) {
         }
 
         if ( 'undefined' !== typeof( reasonVal ) && '' !== rtDeactivate.home_url && '' !== rtDeactivate.user_name ) {
+            $(submitBtn).attr( 'disabled', true );
+
             $.ajax( {
                 url: rtDeactivate.ajax_url,
                 type: 'post',
@@ -70,12 +72,14 @@ jQuery( document ).ready( function ( $ ) {
                     nonce: rtDeactivate.nonce
                 },
                 success: function( response ) {
-                    let flag = JSON.parse( response );
-                    if ( 'success' === flag ) {
-                        $( '.rt-modal-wrapper' ).remove();
-                        let deactivateHref = $( '#deactivate-buddypress-media' ).attr( 'href' );
-                        location.replace( deactivateHref );
-                    }
+                    $( '.rt-modal-wrapper' ).remove();
+                    let deactivateHref = $( '#deactivate-buddypress-media' ).attr( 'href' );
+                    location.replace( deactivateHref );
+                },
+                error: function( error ) {
+                    $( '.rt-modal-wrapper' ).remove();
+                    let deactivateHref = $( '#deactivate-buddypress-media' ).attr( 'href' );
+                    location.replace( deactivateHref );
                 }
             })
         }

--- a/lib/deactivation-survey/deactivation-survey.php
+++ b/lib/deactivation-survey/deactivation-survey.php
@@ -114,9 +114,11 @@ class Deactivation_Survey {
     
             if ( 'integer' === gettype( $response ) ) {
                 echo wp_json_encode( 'success' );
+				wp_die();
             }
         }
 
+	    echo wp_json_encode( 'failed' );
         wp_die();
     }
 


### PR DESCRIPTION
# Fix the plugin deactivation survey issue

- Change the code to handle the different responses of the AJAX call.
- Issue was with the `HTTP` authentication header.
- [rtmedia-dev.rtm.rt.gw](https://rtmedia-dev.rtm.rt.gw/) site is protected with `HTTP` authentication.
- On the production site, there is no HTTP authentication, so it will work fine.
- To test the feature, please disable the `HTTP` authentication from `Easydash` and enable it after the testing.

## Related Issue
- #1934