### PR TITLE
fix(1304) default albums will be visible on group album page

### DIFF
--- a/app/helper/RTMediaModel.php
+++ b/app/helper/RTMediaModel.php
@@ -319,7 +319,7 @@ class RTMediaModel extends RTDBModel {
 		}
 
 		$rtm_post_table = $wpdb->prefix . 'posts';
-		$where          = $wpdb->prepare( " WHERE ( {$this->table_name}.id IN( $sub_sql ) OR (media_type = 'album' AND context_id = %d AND context = 'group') )", $group_id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$where          = $wpdb->prepare( " WHERE ( {$this->table_name}.id IN( $sub_sql ) OR (media_type = 'album' AND (context_id = %d OR context_id IS NULL) AND (context = 'group' OR context IS NULL) ) )", $group_id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$where          = apply_filters( 'rtmedia-get-group-album-where-query', $where, $this->table_name ); // phpcs:ignore
 		$sql   = "SELECT * FROM $this->table_name INNER JOIN $rtm_post_table AS post_table ON post_table.id = $this->table_name.media_id and post_table.post_type = 'rtmedia_album'";

--- a/app/main/controllers/template/RTMediaNav.php
+++ b/app/main/controllers/template/RTMediaNav.php
@@ -278,16 +278,6 @@ class RTMediaNav {
 
 		$global_albums = rtmedia_global_albums();
 
-		// Return the album count if the album has media in it.
-		if ( function_exists( 'bp_is_group' ) && bp_is_group() && $user_group_status ) {
-			$global_albums = array_filter(
-				$global_albums,
-				function ( $album_id ) {
-					return (int) rtm_get_album_media_count( $album_id ) > 0;
-				}
-			);
-		}
-
 		$other_count = count( $global_albums );
 
 		$all = '';


### PR DESCRIPTION
# Fix default albums will be visible on the group album page
- Default albums are not visible on the group album page in the recent version
- This PR fix that issue and also update the count in the navigation bar accordingly

# Reated Issues
- https://github.com/rtCamp/rtMedia-Pro/issues/1304