### PR TITLE
Remove faulty BuddyPress version assignment [pre-release]

### DIFF
--- a/app/main/controllers/template/RTMediaNav.php
+++ b/app/main/controllers/template/RTMediaNav.php
@@ -131,8 +131,6 @@ class RTMediaNav {
 				$media_tab_position = apply_filters( 'rtmedia_group_media_tab_position', 99 );
 
 				// to solve an issue of Media Tab is not showing in version 10.0.0.
-				$bp->version = floatval( $bp->version );
-
 				if ( isset( $bp->version ) && version_compare( $bp->version, '2.5.3', 'gt' ) ) {
 
 					/**


### PR DESCRIPTION
## Description
- Remove faulty BuddyPress version assignment from line no: [L134](https://github.com/rtCamp/rtMedia/blob/ba25ad0dd9686dceb1aa3622930aba2c87b06c2c/app/main/controllers/template/RTMediaNav.php#L134)
- There is no need to assign value to the `BuddyPress::version` data member.

## Related issue
- #2009 