### PR TITLE
Change return value from NULL to false

### DIFF
--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -951,7 +951,7 @@ function rtmedia_duration( $id = false ) {
 	if ( ! empty( $rtmedia_backbone['backbone'] ) ) {
 		echo '<%= duration %>';
 
-		return;
+		return false;
 	}
 
 	if ( $id ) {


### PR DESCRIPTION
- Change the return value from `NULL` to `false` to fix the PHP deprecation error.