### PR TITLE
Enhance security by converting GET into POST request

### DIFF
--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -3881,11 +3881,12 @@ function rtmedia_activate_addon_license( $addon = array() ) {
 	);
 
 	// Call the custom API.
-	$response = wp_remote_get(
-		esc_url_raw( add_query_arg( $api_params, $store_url ) ),
+	$response = wp_remote_post(
+		esc_url_raw( $store_url ),
 		array(
-			'timeout'   => 15,
+			'timeout' => 15,
 			'sslverify' => false,
+			'body' => $api_params,
 		)
 	);
 

--- a/languages/buddypress-media.po
+++ b/languages/buddypress-media.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rtMedia for WordPress, BuddyPress and bbPress 4.6.17\n"
 "Report-Msgid-Bugs-To: https://rtmedia.io/support/\n"
-"POT-Creation-Date: 2024-01-02 06:22:56+00:00\n"
+"POT-Creation-Date: 2024-01-10 12:37:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -69,8 +69,8 @@ msgstr ""
 
 #: app/admin/RTMediaAdmin.php:623 app/admin/RTMediaAdmin.php:1105
 #: app/admin/RTMediaAdmin.php:1106 app/importers/RTMediaActivityUpgrade.php:189
-#: app/importers/RTMediaMigration.php:96 app/main/RTMedia.php:1206
-#: app/main/RTMedia.php:2200
+#: app/importers/RTMediaMigration.php:96 app/main/RTMedia.php:1207
+#: app/main/RTMedia.php:2201
 msgid "rtMedia"
 msgstr ""
 
@@ -2311,7 +2311,7 @@ msgstr ""
 msgid "rtMedia: Import Media Size"
 msgstr ""
 
-#: app/main/RTMedia.php:163 app/main/RTMedia.php:1530 app/main/RTMedia.php:1623
+#: app/main/RTMedia.php:163 app/main/RTMedia.php:1531 app/main/RTMedia.php:1624
 #: app/main/controllers/activity/RTMediaBuddyPressActivity.php:763
 #: app/main/controllers/shortcodes/RTMediaGalleryShortcode.php:113
 #: app/main/controllers/upload/processors/RTMediaUploadFile.php:246
@@ -2366,7 +2366,7 @@ msgstr ""
 msgid "Album"
 msgstr ""
 
-#: app/main/RTMedia.php:882 app/main/RTMedia.php:1426
+#: app/main/RTMedia.php:882 app/main/RTMedia.php:1427
 #: app/main/controllers/media/RTMediaAlbum.php:55
 #: app/main/controllers/media/RTMediaAlbum.php:67
 #: app/main/controllers/template/RTMediaNav.php:317
@@ -2384,107 +2384,107 @@ msgstr ""
 msgid "Wall Post"
 msgstr ""
 
-#: app/main/RTMedia.php:1132 app/main/RTMedia.php:1141
+#: app/main/RTMedia.php:1133 app/main/RTMedia.php:1142
 msgid "Wall Posts"
 msgstr ""
 
-#: app/main/RTMedia.php:1207
+#: app/main/RTMedia.php:1208
 msgid ": Can't Create Database table. Please check create table permission."
 msgstr ""
 
-#: app/main/RTMedia.php:1297 app/main/RTMedia.php:1350
+#: app/main/RTMedia.php:1298 app/main/RTMedia.php:1351
 msgid "Are you sure you want to delete this media?"
 msgstr ""
 
-#: app/main/RTMedia.php:1298
+#: app/main/RTMedia.php:1299
 msgid "Media file deleted successfully."
 msgstr ""
 
-#: app/main/RTMedia.php:1344
+#: app/main/RTMedia.php:1345
 msgid "Loading media"
 msgstr ""
 
-#: app/main/RTMedia.php:1348
+#: app/main/RTMedia.php:1349
 msgid "Please enter some content to post."
 msgstr ""
 
-#: app/main/RTMedia.php:1349
+#: app/main/RTMedia.php:1350
 msgid "Empty comment is not allowed."
 msgstr ""
 
-#: app/main/RTMedia.php:1351
+#: app/main/RTMedia.php:1352
 msgid "Are you sure you want to delete this comment?"
 msgstr ""
 
-#: app/main/RTMedia.php:1352
+#: app/main/RTMedia.php:1353
 msgid "Are you sure you want to delete this Album?"
 msgstr ""
 
-#: app/main/RTMedia.php:1353
+#: app/main/RTMedia.php:1354
 msgid "Drop files here"
 msgstr ""
 
-#: app/main/RTMedia.php:1354
+#: app/main/RTMedia.php:1355
 msgid "album created successfully."
 msgstr ""
 
-#: app/main/RTMedia.php:1355
+#: app/main/RTMedia.php:1356
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: app/main/RTMedia.php:1356
+#: app/main/RTMedia.php:1357
 msgid "Enter an album name."
 msgstr ""
 
-#: app/main/RTMedia.php:1357
+#: app/main/RTMedia.php:1358
 msgid "Max file Size Limit: "
 msgstr ""
 
-#: app/main/RTMedia.php:1358
+#: app/main/RTMedia.php:1359
 msgid "Allowed File Formats"
 msgstr ""
 
-#: app/main/RTMedia.php:1359 templates/media/album-single-edit.php:87
+#: app/main/RTMedia.php:1360 templates/media/album-single-edit.php:87
 msgid "Select All Visible"
 msgstr ""
 
-#: app/main/RTMedia.php:1360
+#: app/main/RTMedia.php:1361
 msgid "Unselect All Visible"
 msgstr ""
 
-#: app/main/RTMedia.php:1361
+#: app/main/RTMedia.php:1362
 msgid "Please select some media."
 msgstr ""
 
-#: app/main/RTMedia.php:1362
+#: app/main/RTMedia.php:1363
 msgid "Are you sure you want to delete the selected media?"
 msgstr ""
 
-#: app/main/RTMedia.php:1363
+#: app/main/RTMedia.php:1364
 msgid "Are you sure you want to move the selected media?"
 msgstr ""
 
-#: app/main/RTMedia.php:1364
+#: app/main/RTMedia.php:1365
 msgid "Waiting"
 msgstr ""
 
-#: app/main/RTMedia.php:1365
+#: app/main/RTMedia.php:1366
 msgid "Uploaded"
 msgstr ""
 
-#: app/main/RTMedia.php:1366
+#: app/main/RTMedia.php:1367
 msgid "Uploading"
 msgstr ""
 
-#: app/main/RTMedia.php:1367
+#: app/main/RTMedia.php:1368
 msgid "Failed"
 msgstr ""
 
-#: app/main/RTMedia.php:1368
+#: app/main/RTMedia.php:1369
 msgid "Close"
 msgstr ""
 
-#: app/main/RTMedia.php:1369
+#: app/main/RTMedia.php:1370
 #: app/main/controllers/media/RTMediaGalleryItemAction.php:88
 #: app/main/controllers/media/RTMediaGalleryItemAction.php:122
 #: app/main/controllers/template/rtmedia-functions.php:1270
@@ -2492,7 +2492,7 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: app/main/RTMedia.php:1370
+#: app/main/RTMedia.php:1371
 #: app/main/controllers/media/RTMediaGalleryItemAction.php:91
 #: app/main/controllers/media/RTMediaGalleryItemAction.php:124
 #: app/main/controllers/template/rtmedia-functions.php:2216
@@ -2501,83 +2501,83 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: app/main/RTMedia.php:1371 templates/media/media-single-edit.php:19
+#: app/main/RTMedia.php:1372 templates/media/media-single-edit.php:19
 msgid "Edit Media"
 msgstr ""
 
-#: app/main/RTMedia.php:1372
+#: app/main/RTMedia.php:1373
 msgid "Remove from queue"
 msgstr ""
 
-#: app/main/RTMedia.php:1373
+#: app/main/RTMedia.php:1374
 msgid "Add more files"
 msgstr ""
 
-#: app/main/RTMedia.php:1374
+#: app/main/RTMedia.php:1375
 msgid "File not supported"
 msgstr ""
 
-#: app/main/RTMedia.php:1375
+#: app/main/RTMedia.php:1376
 msgid "more"
 msgstr ""
 
-#: app/main/RTMedia.php:1376
+#: app/main/RTMedia.php:1377
 msgid "less"
 msgstr ""
 
-#: app/main/RTMedia.php:1377
+#: app/main/RTMedia.php:1378
 msgid "Read more"
 msgstr ""
 
-#: app/main/RTMedia.php:1378
+#: app/main/RTMedia.php:1379
 msgid "Show less"
 msgstr ""
 
-#: app/main/RTMedia.php:1380
+#: app/main/RTMedia.php:1381
 msgid "This media is uploaded. Are you sure you want to delete this media?"
 msgstr ""
 
-#: app/main/RTMedia.php:1400
+#: app/main/RTMedia.php:1401
 msgid "Featured media set successfully."
 msgstr ""
 
-#: app/main/RTMedia.php:1401
+#: app/main/RTMedia.php:1402
 msgid "Featured media removed successfully."
 msgstr ""
 
-#: app/main/RTMedia.php:1407
+#: app/main/RTMedia.php:1408
 msgid "Title:"
 msgstr ""
 
-#: app/main/RTMedia.php:1408
+#: app/main/RTMedia.php:1409
 msgid "Description:"
 msgstr ""
 
-#: app/main/RTMedia.php:1412
+#: app/main/RTMedia.php:1413
 msgid "Oops !! There's no media found for the request !!"
 msgstr ""
 
-#: app/main/RTMedia.php:1416
+#: app/main/RTMedia.php:1417
 msgid "Edit File Name"
 msgstr ""
 
-#: app/main/RTMedia.php:1427
+#: app/main/RTMedia.php:1428
 msgid "Privacy updated successfully."
 msgstr ""
 
-#: app/main/RTMedia.php:1428
+#: app/main/RTMedia.php:1429
 msgid "Couldn't change privacy, please try again."
 msgstr ""
 
-#: app/main/RTMedia.php:1466
+#: app/main/RTMedia.php:1467
 msgid "There are some uploads in progress. Do you want to cancel them?"
 msgstr ""
 
-#: app/main/RTMedia.php:1468
+#: app/main/RTMedia.php:1469
 msgid "Media upload is disabled. Please Enable at least one media type to proceed."
 msgstr ""
 
-#: app/main/RTMedia.php:1579
+#: app/main/RTMedia.php:1580
 msgid "Adding media in Comments is not allowed"
 msgstr ""
 
@@ -3152,12 +3152,12 @@ msgid "Merge Album"
 msgstr ""
 
 #: app/main/controllers/template/rtmedia-filters.php:966
-#: app/main/controllers/template/rtmedia-functions.php:4643
+#: app/main/controllers/template/rtmedia-functions.php:4644
 msgid "rtMedia Shortcode Uploads"
 msgstr ""
 
 #: app/main/controllers/template/rtmedia-filters.php:970
-#: app/main/controllers/template/rtmedia-functions.php:4524
+#: app/main/controllers/template/rtmedia-functions.php:4525
 msgid "rtMedia Activities"
 msgstr ""
 
@@ -3166,12 +3166,12 @@ msgid "rtMedia Comments"
 msgstr ""
 
 #: app/main/controllers/template/rtmedia-filters.php:978
-#: app/main/controllers/template/rtmedia-functions.php:4872
+#: app/main/controllers/template/rtmedia-functions.php:4873
 msgid "rtMedia Media Views"
 msgstr ""
 
 #: app/main/controllers/template/rtmedia-filters.php:982
-#: app/main/controllers/template/rtmedia-functions.php:4973
+#: app/main/controllers/template/rtmedia-functions.php:4974
 msgid "rtMedia Media Likes"
 msgstr ""
 
@@ -3278,63 +3278,63 @@ msgid_plural "%s hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/main/controllers/template/rtmedia-functions.php:3974
+#: app/main/controllers/template/rtmedia-functions.php:3975
 #. translators: %s: date format, see http:php.net/date.
 msgid "View Conversation"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4550
+#: app/main/controllers/template/rtmedia-functions.php:4551
 msgid "Activity Date"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4554
+#: app/main/controllers/template/rtmedia-functions.php:4555
 msgid "Activity Content"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4558
-#: app/main/controllers/template/rtmedia-functions.php:4782
+#: app/main/controllers/template/rtmedia-functions.php:4559
+#: app/main/controllers/template/rtmedia-functions.php:4783
 msgid "Attachments"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4652
+#: app/main/controllers/template/rtmedia-functions.php:4653
 msgid "Media Upload Date"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4656
+#: app/main/controllers/template/rtmedia-functions.php:4657
 msgid "Media Title"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4660
-#: app/main/controllers/template/rtmedia-functions.php:4876
-#: app/main/controllers/template/rtmedia-functions.php:4977
+#: app/main/controllers/template/rtmedia-functions.php:4661
+#: app/main/controllers/template/rtmedia-functions.php:4877
+#: app/main/controllers/template/rtmedia-functions.php:4978
 msgid "Media URL"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4664
+#: app/main/controllers/template/rtmedia-functions.php:4665
 msgid "Album Title"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4753
+#: app/main/controllers/template/rtmedia-functions.php:4754
 msgid "rtMedia Activity Comments"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4774
+#: app/main/controllers/template/rtmedia-functions.php:4775
 msgid "Comment Date"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4778
+#: app/main/controllers/template/rtmedia-functions.php:4779
 msgid "Comment Content"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4880
+#: app/main/controllers/template/rtmedia-functions.php:4881
 msgid "Number of Views"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4884
+#: app/main/controllers/template/rtmedia-functions.php:4885
 msgid "Date of First View"
 msgstr ""
 
-#: app/main/controllers/template/rtmedia-functions.php:4981
+#: app/main/controllers/template/rtmedia-functions.php:4982
 msgid "Date"
 msgstr ""
 


### PR DESCRIPTION
## Description
- A license validation request is sent from the plugin to check the license validity of a particular Addon, which is now part of the `rtMedia Pro` plugin and is no longer available to purchase alone as an `Add-on`( since more than a year ).
- This add-on license validation is not removed from the plugin to add backward compatibility.
- This issue is resolved by replacing the `GET` request with the `POST` request, which is also suggested on the official docs of the EDD Software Licensing plugin. See [this](https://easydigitaldownloads.com/docs/software-licensing-activating-checking-and-deactivating-license-keys-in-wordpress-plugins/) for more info.

## Related issue
- #2036