### PR TITLE
Fix: Create Album Signature [ Develop ]

### DIFF
--- a/app/importers/BPMediaAlbumimporter.php
+++ b/app/importers/BPMediaAlbumimporter.php
@@ -222,8 +222,13 @@ class BPMediaAlbumimporter extends BPMediaImporter {
 	 *
 	 * @return mixed
 	 */
-	public function create_album( $author_id, $album_name = 'Imported Media' ) {
+	public function create_album( $album_name = '', $author_id = 1 )  {
 		global $bp_media, $wpdb;
+
+		// Set album_name to 'Imported Media' if it is empty.
+		if ( empty( $album_name ) ) {
+			$album_name = 'Imported Media';
+		}
 
 		if ( array_key_exists( 'bp_album_import_name', $bp_media->options ) ) {
 			if ( '' !== $bp_media->options['bp_album_import_name'] ) {

--- a/lib/deactivation-survey/deactivation-survey.php
+++ b/lib/deactivation-survey/deactivation-survey.php
@@ -44,9 +44,9 @@ class Deactivation_Survey {
                 'It\'s not what I was looking for.',
                 'The plugin didn\'t work as expected.',
             ];
-    
+
             $current_user = wp_get_current_user();
-    
+
             $rt_deactivate = [
                 'home_url'    => home_url(),
                 'admin_url'   => admin_url(),
@@ -57,7 +57,7 @@ class Deactivation_Survey {
                 'user_email'  => $current_user->user_email,
                 'header_text' => esc_html__( 'If you have a moment, please let us know why you are deactivating: ', 'buddypress-media' )
             ];
-    
+
             wp_localize_script( 'rt-deactivation-survey', 'rtDeactivate', $rt_deactivate );
         }
     }
@@ -100,7 +100,7 @@ class Deactivation_Survey {
                 'body'             => $data,
                 'headers'          => [
                     'Content-type' => "application/x-www-form-urlencoded",
-                    'Authorization' => "Basic " . base64_encode("${auth_user}:${auth_password}")
+                    'Authorization' => "Basic " . base64_encode("{$auth_user}:{$auth_password}")
                 ],
                 'timeout'          => 60,
                 'redirection'      => 5,
@@ -111,7 +111,7 @@ class Deactivation_Survey {
 
             $api_response = wp_remote_post( $this->api_url . '/survey', $options );
             $response     = json_decode( wp_remote_retrieve_body( $api_response ) );
-    
+
             if ( 'integer' === gettype( $response ) ) {
                 echo wp_json_encode( 'success' );
 				wp_die();


### PR DESCRIPTION
## Create Album Signature 

### Issues
- An error of type E_COMPILE_ERROR was caused in line 225 of the file /nas/content/live/movarahomedev/wp-content/plugins/buddypress-media/app/importers/BPMediaAlbumimporter.php
- Error message: Declaration of BPMediaAlbumimporter::create_album($author_id, $album_name = ‘Imported M…’) must be compatible with BPMediaImporter::create_album($album_name = ”, $author_id = 1)

### Fixes
- Update the order of params in the `create_album` function 
- Add condition to set the default value.
- Update String Interpolation for Plugin Deactivation Survery.