### PR TITLE
rtMedia Uploader Widget not showing on homepage(index.php) template

### DIFF
--- a/app/main/controllers/shortcodes/RTMediaUploadShortcode.php
+++ b/app/main/controllers/shortcodes/RTMediaUploadShortcode.php
@@ -55,7 +55,7 @@ class RTMediaUploadShortcode {
 		$media_enabled = ( is_rtmedia_upload_music_enabled() || is_rtmedia_upload_photo_enabled()
 			|| is_rtmedia_upload_video_enabled() || is_rtmedia_upload_document_enabled()
 			|| is_rtmedia_upload_other_enabled() );
-		$flag          = ( ! ( is_home() || is_post_type_archive() || is_author() ) )
+		$flag          = ( ! (is_post_type_archive() || is_author() ) )
 		&& is_user_logged_in()
 		&& ( $media_enabled )
 		// Added condition to disable upload when media is disabled in profile/group but user visits media tab.


### PR DESCRIPTION
When adding rtMedia Uploader, It was being shown in every other template but the index.php. So I removed the check from RTMediaUploadShortcode.display_allowed() which skip displaying for homepage.