### PR TITLE
Fix sorting for size and title of media.

### DIFF
--- a/app/helper/RTMediaModel.php
+++ b/app/helper/RTMediaModel.php
@@ -122,7 +122,7 @@ class RTMediaModel extends RTDBModel {
 		}
 		$qgroup_by = ' ';
 
-		$allowed_order_columns = array( 'media_id', 'date', 'name' ); // Define allowed columns.
+		$allowed_order_columns = array( 'media_id', 'media_title','file_size'); // Define allowed columns.
 		list( $order_column, $order_direction ) = explode( ' ', $order_by . ' ' ); // Default to space if no direction provided.
 
 		if ( ! in_array( strtolower( $order_column ), $allowed_order_columns ) || ! in_array(


### PR DESCRIPTION
Issue Link: https://github.com/rtCamp/rtMedia-Pro/issues/1447

Initially, the table columns provided did not match the exact table names, which caused the sorting to not work as the query was incorrect.