### PR TITLE
Fix Sorting by Rate and Likes. [ develop ]

### DIFF
--- a/app/helper/RTMediaModel.php
+++ b/app/helper/RTMediaModel.php
@@ -122,7 +122,7 @@ class RTMediaModel extends RTDBModel {
 		}
 		$qgroup_by = ' ';
 
-		$allowed_order_columns = array( 'media_id', 'media_title','file_size'); // Define allowed columns.
+		$allowed_order_columns = array( 'media_id', 'media_title', 'file_size', 'ratings_average', 'likes' ); // Define allowed columns.
 		list( $order_column, $order_direction ) = explode( ' ', $order_by . ' ' ); // Default to space if no direction provided.
 
 		if ( ! in_array( strtolower( $order_column ), $allowed_order_columns ) || ! in_array(


### PR DESCRIPTION
Issue: https://github.com/rtCamp/rtMedia/issues/2051

Add ratings_average and likes in allowed_order_columns array so that sorting with rate and like is possible.