### PR TITLE
Make media upload field mandatory & enhance aria-labels for accessibility

### DIFF
--- a/templates/upload/uploader.php
+++ b/templates/upload/uploader.php
@@ -82,7 +82,7 @@ if ( is_array( $tabs ) && count( $tabs ) ) { ?>
 					?>
 					<div class="rtm-file-input-container">
 						<p class="rtmedia-file-upload-p">
-							<input type="file" name="rtmedia_file_multiple[]" multiple="true" class="rtm-simple-file-input" id="rtmedia_simple_file_input" />
+                            <input type="file" name="rtmedia_file_multiple[]" multiple="true" class="rtm-simple-file-input" id="rtmedia_simple_file_input" aria-label="Select media files to upload" multiple required/>
 						</p>
 					</div>
 					<?php
@@ -90,7 +90,7 @@ if ( is_array( $tabs ) && count( $tabs ) ) { ?>
 					?>
 					<div class="rtm-file-input-container">
 						<p class="rtmedia-file-upload-p">
-							<input type="file" name="rtmedia_file" class="rtm-simple-file-input" id="rtmedia_simple_file_input" />
+                            <input type="file" name="rtmedia_file" class="rtm-simple-file-input" id="rtmedia_simple_file_input" aria-label="Select a media file to upload"  required/>
 						</p>
 					</div>
 					<?php
@@ -104,7 +104,7 @@ if ( is_array( $tabs ) && count( $tabs ) ) { ?>
 					<?php
 				} else {
 					?>
-						<p><input type="submit" name="rtmedia_simple_file_upload_submit" /></p>
+						<p><input type="submit" name="rtmedia_simple_file_upload_submit" aria-label="Upload selected media file" /></p>
 					</div>
 			</form>
 					<?php
@@ -152,7 +152,8 @@ if ( is_array( $tabs ) && count( $tabs ) ) { ?>
 					}
 					?>
 
-					<input type="submit" id='rtMedia-start-upload' name="rtmedia-upload" value="<?php echo esc_attr( RTMEDIA_UPLOAD_LABEL ); ?>" />
+					<input type="submit" id='rtMedia-start-upload' name="rtmedia-upload" value="<?php echo esc_attr( RTMEDIA_UPLOAD_LABEL ); ?>" aria-label="Start media upload" />
+
 
 				</div>
 			</div>


### PR DESCRIPTION
### Changes made:
- Added `required` attribute to media upload `<input type="file">` in `templates/upload/uploader.php` to prevent empty uploads.
- Improved `aria-label` attributes for better accessibility and screen reader support.

### Testing:
- Verified that the upload form cannot be submitted without selecting a file.
- Checked that screen readers announce the file upload field clearly with the updated aria-label.

Closes: #2154
