### PR TITLE
Fix: Missing Authorization to Unauthenticated Information Disclosure via handle_rest_pre_dispatch Function

### DIFF
--- a/app/main/controllers/api/RTMediaJsonApi.php
+++ b/app/main/controllers/api/RTMediaJsonApi.php
@@ -161,10 +161,6 @@ class RTMediaJsonApi {
 
 		add_action( 'wp_ajax_nopriv_rtmedia_api', array( $this, 'rtmedia_api_process_request' ) );
 		add_action( 'wp_ajax_rtmedia_api', array( $this, 'rtmedia_api_process_request' ) );
-
-		if ( defined( 'RTMEDIA_GODAM_ACTIVE' ) && RTMEDIA_GODAM_ACTIVE ) {
-			add_action( 'rest_api_init', [ $this, 'register_rest_pre_dispatch_filter' ] );
-		}
 	}
 
 	/**
@@ -1472,40 +1468,5 @@ class RTMediaJsonApi {
 
 			return $args;
 		}
-	}
-
-	/**
-	 * Registers the rest_pre_dispatch filter during rest_api_init.
-	 */
-	public function register_rest_pre_dispatch_filter() {
-		add_filter( 'rest_pre_dispatch', [ $this, 'handle_rest_pre_dispatch' ], 10, 3 );
-	}
-
-	/**
-	 * Callback for rest_pre_dispatch filter.
-	 *
-	 * @param mixed           $result  Result to return instead of the request. Default null to continue with request.
-	 * @param WP_REST_Server  $server  Server instance.
-	 * @param WP_REST_Request $request Request object.
-	 *
-	 * @return mixed Modified result or original $result.
-	 */
-	public function handle_rest_pre_dispatch( $result, $server, $request ) {
-		$route  = $request->get_route();
-		$method = $request->get_method();
-
-		if ( 'GET' === $method && preg_match( '#^/wp/v2/media/(\d+)$#', $route, $matches ) ) {
-			$media_id = (int) $matches[1];
-			$post     = get_post( $media_id );
-
-			if ( $post && 'attachment' === $post->post_type ) {
-				$controller = new WP_REST_Attachments_Controller( 'attachment' );
-				$response   = $controller->prepare_item_for_response( $post, $request );
-
-				return rest_ensure_response( $response );
-			}
-		}
-
-		return $result;
 	}
 }


### PR DESCRIPTION
**Fix issue:** rtMedia for WordPress, BuddyPress and bbPress 4.7.0 – 4.7.1 — Missing Authorization to Unauthenticated Information Disclosure via handle_rest_pre_dispatch Function
Ref doc: https://docs.google.com/document/d/1Z2nAE-nn4SvmutUEckc6pA6SSN-rM_aF/edit

This pull request removes custom REST API integration logic from the `RTMediaJsonApi` controller. The main change is the deletion of the conditional registration and handling of the `rest_pre_dispatch` filter, which was used to intercept media GET requests and prepare custom responses. 

## Explaination
On the rtMedia plugin, we are applying the `handle_rest_pre_dispatch()` function on `rest_pre_dispatch` hook when the GoDAM plugin is active, to get the attachment information in all cases.

I recall that initially, we were receiving a below response on the video editor for some media attachments (Note: users were receiving this message because they did not have sufficient permission to edit specific media). To resolve the issue, the rtMedia team may have added this function on the `rest_pre_dispatch` hook, which is no longer needed.

```
{"code":"rest_forbidden","message":"Sorry, you are not allowed to do that.","data":{"status":401}}
```

## Related issue: https://github.com/rtCamp/rtmedia-io/issues/1684#event-20074973749