### PR TITLE
rtMedia Gallery Allowed Media Upload of all types for different Media types

### DIFF
--- a/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
+++ b/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
@@ -99,6 +99,19 @@ class RTMediaGalleryShortcode {
 		$request_uri = rtm_get_server_var( 'REQUEST_URI', 'FILTER_SANITIZE_URL' );
 		$url         = rtmedia_get_upload_url( $request_uri );
 
+		// Get all allowed media types from rtMedia.
+		$allowed_types = rtmedia_get_allowed_types();
+		$allowed_extensions = get_rtmedia_allowed_upload_type(); // Default fallback.
+
+		// Dynamically detect current media type based on the request URI.
+		if ( false !== strpos( $request_uri, '/photo/' ) && ! empty( $allowed_types['photo']['extn'] ) ) {
+			$allowed_extensions = implode( ',', $allowed_types['photo']['extn'] );
+		} elseif ( false !== strpos( $request_uri, '/video/' ) && ! empty( $allowed_types['video']['extn'] ) ) {
+			$allowed_extensions = implode( ',', $allowed_types['video']['extn'] );
+		} elseif ( false !== strpos( $request_uri, '/music/' ) && ! empty( $allowed_types['music']['extn'] ) ) {
+			$allowed_extensions = implode( ',', $allowed_types['music']['extn'] );
+		}
+
 		$upload_max_size = ( wp_max_upload_size() ) / ( 1024 * 1024 ) . 'M';
 		$params          = array(
 			'url'                 => $url,
@@ -111,7 +124,7 @@ class RTMediaGalleryShortcode {
 				array(
 					array(
 						'title'      => esc_html__( 'Media Files', 'buddypress-media' ),
-						'extensions' => get_rtmedia_allowed_upload_type(),
+						'extensions' => $allowed_extensions,
 					),
 				)
 			),

--- a/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
+++ b/app/main/controllers/shortcodes/RTMediaGalleryShortcode.php
@@ -110,6 +110,8 @@ class RTMediaGalleryShortcode {
 			$allowed_extensions = implode( ',', $allowed_types['video']['extn'] );
 		} elseif ( false !== strpos( $request_uri, '/music/' ) && ! empty( $allowed_types['music']['extn'] ) ) {
 			$allowed_extensions = implode( ',', $allowed_types['music']['extn'] );
+		} elseif ( false !== strpos( $request_uri, '/document/' ) && ! empty( $allowed_types['document']['extn'] ) ) {
+			$allowed_extensions = implode( ',', $allowed_types['document']['extn'] );
 		}
 
 		$upload_max_size = ( wp_max_upload_size() ) / ( 1024 * 1024 ) . 'M';


### PR DESCRIPTION
Issue: https://github.com/rtCamp/rtMedia/issues/2180

Fix:
- Previously in the rtMedia Gallery if we are on Video tab for example then we would be able to upload other media types also through the Uploader, similarly for other tabs also.
- Updated the code so that now only the Allowed extension type for different media types would be selectable from the File Uploader.

Allowed File Extension types:

Image: `jpg, jpeg, png, gif`
Video: `mp4`
Audio: `mp3`

