### PR TITLE
Fixed typo on readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,7 @@ rtMedia has a premium solution to take care of audio/video conversion.
 
 = Important Links =
 
-* [Project Homepage](https://rtmedio.io/?utm_source=readme&utm_medium=plugin&utm_campaign=buddypress-media "Visit rtMedia's Project Homepage")
+* [Project Homepage](https://rtmedia.io/?utm_source=readme&utm_medium=plugin&utm_campaign=buddypress-media "Visit rtMedia's Project Homepage")
 * [Roadmap](https://rtmedia.io/roadmap/?utm_source=readme&utm_medium=plugin&utm_campaign=buddypress-media "Visit rtMedia's Roadmap page")
 * [Documentation](https://rtmedia.io/docs/?utm_source=readme&utm_medium=plugin&utm_campaign=buddypress-media "Visit rtMedia's Documentation page")
 * [FAQ](https://rtmedia.io/faq/?utm_source=readme&utm_medium=plugin&utm_campaign=buddypress-media "Visit rtMedia's FAQ page")


### PR DESCRIPTION
This PR fixes a typo in the readme.txt file that was pointing to an incorrect URL. The incorrect link has been updated to the correct one, ensuring users are directed to the proper destination.

## Changes Made:

Corrected the malformed URL in readme.txt
Verified that the new link resolves correctly

## Why This Matters:

Fixing this typo improves documentation accuracy and user experience by preventing navigation to an invalid or unintended location.