### PR TITLE
Add documentation related changes

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,6 +8,8 @@
  * Text Domain: buddypress-media
  * Author URI: http://rtcamp.com/?utm_source=dashboard&utm_medium=plugin&utm_campaign=buddypress-media
  * Domain Path: /languages/
+ * License: GPLv2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  *
  * Main file, contains the plugin metadata and activation processes
  *

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: rtcamp, mangeshp, sanket.parmar, pranalipatel, jignesh.nakrani, ma
 Tags: BuddyPress, media, multimedia, album, audio, music, video, photo, upload, share, MediaElement.js, media-node, rtMedia, WordPress, bbPress, masonry
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Requires at least: WordPress 4.1
-Tested up to: 6.8.1
+Requires at least: 4.1
+Tested up to: 6.8
 Stable tag: 4.7.3
 
 Add albums, photo, audio/video upload, privacy, sharing, front-end uploads & more. All this works on mobile/tablets devices.


### PR DESCRIPTION
This pull request makes minor updates to the plugin metadata in both the `index.php` and `readme.txt` files, focusing on clarifying licensing information and adjusting the WordPress compatibility details.

- **Licensing Information Updates**
  * Added explicit `License` and `License URI` fields to the plugin header in `index.php` to clarify the plugin's GPLv2 licensing.

- **WordPress Compatibility Adjustments**
  * Updated the `Requires at least` and `Tested up to` fields in `readme.txt` for more accurate WordPress version compatibility (now "Requires at least: 4.1" and "Tested up to: 6.8").
  
## Related Issue:
[Codebase sweep and vulnerability reporting around rtMedia plugin (rtCamp/rtmedia-io#1684)](https://github.com/rtCamp/rtmedia-io/issues/1684)