### PR TITLE
fix: Refactor Playwright tests for media type validation

### DIFF
--- a/tests/wp-e2e-playwright/specs/types.spec.js
+++ b/tests/wp-e2e-playwright/specs/types.spec.js
@@ -15,7 +15,7 @@ test.describe("Validate media types", () => {
         selectorToReset = null; // Reset tracker
     });
 
-    test.afterEach(async ({ admin }) => {
+    test.afterEach(async ({ page, admin }) => {
         if (selectorToReset) {
             await admin.visitAdminPage("admin.php?page=rtmedia-settings#rtmedia-types");
             await backend.enableAnySettingAndSave(selectorToReset);


### PR DESCRIPTION
<img width="2372" height="702" alt="image" src="https://github.com/user-attachments/assets/7da47dc6-95a3-4668-b97a-5afb3e5356bb" />

The Playwright tests for the media type validation keeps failing due to incorrect strings.

This PR fixes the strings and makes the validation robust.