### PR TITLE
Fix rtMedia Compatibility with Hello Elementor Theme

### DIFF
--- a/app/main/routers/RTMediaRouter.php
+++ b/app/main/routers/RTMediaRouter.php
@@ -225,8 +225,8 @@ class RTMediaRouter {
 	}
 
 	/**
-	 * "the_content" filter won't work on FSE themes e.g Twenty Twenty-Tow.
-	 * The following add supports for block theme.
+	 * "the_content" filter won't work on FSE themes e.g Twenty Twenty-Two.
+	 * The following adds support for block themes.
 	 *
 	 * @param string $content Content.
 	 * @param array  $parsed_block blocks.
@@ -234,7 +234,9 @@ class RTMediaRouter {
 	 * @return string $content
 	 */
 	public function rt_replace_the_content_fse( $content, $parsed_block ) {
-		if ( 'core/post-template' === $parsed_block['blockName'] ) {
+		// core/post-template: Used in archive/query loop templates.
+		// core/post-content: Used in single post/page templates.
+		if ( 'core/post-template' === $parsed_block['blockName'] || 'core/post-content' === $parsed_block['blockName'] ) {
 			return $this->rt_replace_the_content();
 		}
 
@@ -294,7 +296,8 @@ class RTMediaRouter {
 
 					'is_404'                => false,
 					'is_page'               => false,
-					'is_single'             => false,
+					'is_single'             => true,
+					'is_singular'           => true,
 					'is_archive'            => false,
 					'is_tax'                => false,
 				)
@@ -329,7 +332,8 @@ class RTMediaRouter {
 					'filter'                => 'raw',
 					'is_404'                => false,
 					'is_page'               => false,
-					'is_single'             => false,
+					'is_single'             => true,
+					'is_singular'           => true,
 					'is_archive'            => false,
 					'is_tax'                => false,
 				)
@@ -393,12 +397,13 @@ class RTMediaRouter {
 		$wp_query->posts = array( $post );
 
 		// Prevent comments form from appearing.
-		$wp_query->post_count = 1;
-		$wp_query->is_404     = $dummy['is_404'];
-		$wp_query->is_page    = $dummy['is_page'];
-		$wp_query->is_single  = $dummy['is_single'];
-		$wp_query->is_archive = $dummy['is_archive'];
-		$wp_query->is_tax     = $dummy['is_tax'];
+		$wp_query->post_count  = 1;
+		$wp_query->is_404      = $dummy['is_404'];
+		$wp_query->is_page     = $dummy['is_page'];
+		$wp_query->is_single   = $dummy['is_single'];
+		$wp_query->is_singular = $dummy['is_singular'];
+		$wp_query->is_archive  = $dummy['is_archive'];
+		$wp_query->is_tax      = $dummy['is_tax'];
 
 		// Clean up the dummy post.
 		unset( $dummy );


### PR DESCRIPTION
## Summary

Fixes an issue where rtMedia Media tab show "The page can't be found" error when using Elementor's Hello theme.

## Problem

When using Hello Elementor theme, visiting media pages (e.g., `/members/admin/media/`) displays a 404 error instead of the media gallery. This happens because Hello Elementor's minimal template structure checks `is_singular()` before loading the content template, and rtMedia wasn't setting this flag correctly.

## Solution

### 1. Set Correct Query Flags

Updated `rt_theme_compat_reset_post()` in `RTMediaRouter.php` to properly set WordPress query flags:

```php
// Before
'is_single'   => false,

// After  
'is_single'   => true,
'is_singular' => true,
```

This makes `is_singular()` return `true` for rtMedia pages, allowing themes like Hello Elementor to load the correct template that calls `the_content()`.

### 2. Enhanced FSE Block Support

Added support for `core/post-content` block in addition to `core/post-template`:

```php
// Before
if ( 'core/post-template' === $parsed_block['blockName'] ) {

// After
if ( 'core/post-template' === $parsed_block['blockName'] || 'core/post-content' === $parsed_block['blockName'] ) {
```

This improves compatibility with FSE themes that use the post-content block in single templates.

## Changes

- **File:** `app/main/routers/RTMediaRouter.php`
  - `rt_theme_compat_reset_post()`: Changed `is_single` from `false` to `true`, added `is_singular` set to `true`
  - `rt_replace_the_content_fse()`: Added `core/post-content` block name check

## Testing

| Theme | Before | After |
|-------|--------|-------|
| Hello Elementor | ❌ 404 Error | ✅ Works |
| Twenty Twenty-Five (FSE) | ✅ Works | ✅ Works |
| Twenty Twenty-One (Classic) | ✅ Works | ✅ Works |
| BuddyPress Default | ✅ Works | ✅ Works |

### Test Steps

1. Activate Hello Elementor theme
2. Activate BuddyPress and rtMedia plugins
3. Visit `/members/{username}/media/`
4. Expected: Media gallery displays correctly
<img width="1452" height="696" alt="Image" src="https://github.com/user-attachments/assets/376caf66-5933-4d0c-9d3a-6e32ccf0ba83" />
5. Previously: "The page can't be found" error
<img width="1470" height="593" alt="Image" src="https://github.com/user-attachments/assets/531df572-716e-4774-ad8c-d3f19b81c6a2" />

## Related Issue

Fixes: #2225 

