### PR TITLE
fix(update) : PHP 8.4 Compatibility 

### DIFF
--- a/app/importers/BPMediaAlbumimporter.php
+++ b/app/importers/BPMediaAlbumimporter.php
@@ -670,6 +670,6 @@ class BPMediaAlbumimporter extends BPMediaImporter {
 		if ( ! check_ajax_referer( 'bpmedia-bpalbumimporter', 'rtm_wpnonce' ) ) {
 			deactivate_plugins( 'bp-album/loader.php' );
 		}
-		die( true );
+		exit;
 	}
 }


### PR DESCRIPTION
## ✅ PHP 8.4 Compatibility Summary & Fixes

### **1. Required Fix**
**File:** `app/importers/BPMediaAlbumimporter.php`  
**Issue:** `die(true)` is deprecated in PHP 8.4 (parameter must be a string or integer).  
**Fix:** Replace deprecated function usage.

**Change line 673 from:**
```php
die(true);
```

**To:**
```php
exit;
```

---

### **2. Safe to Ignore (No Code Changes Needed)**

| File / Log | Issue | Reason |
|-----------|--------|---------|
| `RTMediaUploadFile.php` | `read_exif_data()` deprecated | Wrapped in `function_exists()` check → safe fallback |
| `getid3.php` | `get_magic_quotes_runtime()` deprecated | Inside `version_compare()` guard, does not execute on modern PHP |
| `extension.cache.mysql.php` | 50+ `mysql_*` deprecated functions | Dead/unused file, never executed |
| General logs | `safe_mode` warnings | Harmless checks for removed INI setting |
| General logs | `utf8_encode()` / `utf8_decode()` deprecated | Still functional in PHP 8.4, only produces noise |
| `node_modules/` warnings | Dependency build logs | Development-only files, not executed on production |

---

### **Conclusion**
Only a **single change** is required to remove an actual runtime deprecation.  
Everything else is safely handled or unused and does **not** require modification.
