### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - '*'
+
+permissions:
+  contents: read
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpcs_on_pull_request.yml
+++ b/.github/workflows/phpcs_on_pull_request.yml
@@ -1,5 +1,10 @@
 on: pull_request
 name: Inspections
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   runPHPCSInspection:
     name: Run PHPCS inspection

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Run-wpe2e-TestCase:
     # The type of runner that the job will run on


### PR DESCRIPTION
## Summary

This PR adds explicit `permissions:` blocks to all GitHub Actions workflows to follow the principle of least privilege and resolve security scanning alerts.

## Changes

### 1. **phpcs_on_pull_request.yml**
- Added `permissions: contents: read, pull-requests: write`
- Grants minimal permissions needed to checkout code and post PR comments

### 2. **create.yml**
- Added `permissions: contents: read`
- Grants read-only access for code checkout and WordPress.org deployment via SVN

### 3. **playwright.yml**
- Added `permissions: contents: read`
- Grants read-only access for code checkout and running E2E tests

## Security Impact

**Resolves:** Code scanning alerts [#1](https://github.com/rtCamp/rtMedia/security/code-scanning/1), [#2](https://github.com/rtCamp/rtMedia/security/code-scanning/2), [#39](https://github.com/rtCamp/rtMedia/security/code-scanning/39)

Previously, these workflows ran with default GITHUB_TOKEN permissions which could be overly permissive. This change explicitly limits each workflow to only the permissions it needs.

## References

- GitHub Documentation: [Workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- Related issue: rtCamp/support#245