### PR TITLE
Refactor gallery search query building

### DIFF
--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -772,7 +772,7 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			if ( ! empty( $search_by ) ) {
 
 				if ( ! empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " $table_name.album_id = %s AND ", $rtmedia_current_album ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.album_id = %d AND ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 
 				if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
@@ -798,7 +798,7 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			} else {
 
 				if ( ! empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " $table_name.album_id = %s AND ", $rtmedia_current_album ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.album_id = %d AND ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 
 				if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
@@ -824,7 +824,7 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 
 			// Reset data for album's media.
 			if ( '' !== $search && ! empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " AND $table_name.album_id = %s ", $rtmedia_current_album ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " AND $table_name.album_id = %d ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}
 
 			// Reset data for particular media type.
@@ -873,10 +873,13 @@ function rtmedia_search_fillter_join_query( $join, $table_name ) {
 			$request_uri = rtm_get_server_var( 'REQUEST_URI', 'FILTER_SANITIZE_URL' );
 			$request_url = explode( '/', $request_uri );
 			if ( ! empty( $search_by ) && 'attribute' === $search_by && ! in_array( 'attribute', $request_url, true ) ) {
-				$join .= " 	INNER JOIN $posts_table ON ( $posts_table.ID = $table_name.media_id AND $posts_table.post_type = '$media_type' )
-		                    INNER JOIN $terms_table ON ( $terms_table.slug IN (" . $wpdb->prepare( '%s', $search ) . ") )
+				$join .= $wpdb->prepare(
+					" 	INNER JOIN $posts_table ON ( $posts_table.ID = $table_name.media_id AND $posts_table.post_type = '$media_type' )
+		                    INNER JOIN $terms_table ON ( $terms_table.slug IN (%s) )
 		                    INNER JOIN $term_taxonomy_table ON ( $term_taxonomy_table.term_id = $terms_table.term_id )
-		                    INNER JOIN $term_relationships_table ON ( $term_relationships_table.term_taxonomy_id = $term_taxonomy_table.term_taxonomy_id AND $term_relationships_table.object_id = $posts_table.ID ) ";
+		                    INNER JOIN $term_relationships_table ON ( $term_relationships_table.term_taxonomy_id = $term_taxonomy_table.term_taxonomy_id AND $term_relationships_table.object_id = $posts_table.ID ) ",
+					$search
+				); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}
 		}
 	}

--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -747,13 +747,15 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 
 	if ( function_exists( 'rtmedia_media_search_enabled' ) && rtmedia_media_search_enabled() ) {
 
+		global $wpdb;
+
 		$raw_search = wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( 'string' !== gettype( $raw_search ) ) {
 			$raw_search = '';
 		}
 
-		$search                = sanitize_text_field( urldecode( $raw_search ) );
+		$search                = sanitize_text_field( $raw_search );
 		$search_by             = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'search_by', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 		$media_type            = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'media_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
 		$rtmedia_current_album = sanitize_text_field( wp_unslash( filter_input( INPUT_GET, 'rtmedia-current-album', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) );
@@ -770,17 +772,17 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			if ( ! empty( $search_by ) ) {
 
 				if ( ! empty( $rtmedia_current_album ) ) {
-					$where .= " $table_name.album_id = '" . $rtmedia_current_album . "' AND ";
+					$where .= $wpdb->prepare( " $table_name.album_id = %s AND ", $rtmedia_current_album ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 
 				if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
-					$where .= " $table_name.media_type = '" . $media_type . "' AND ";
+					$where .= $wpdb->prepare( " $table_name.media_type = %s AND ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 
 				if ( 'title' === $search_by ) {
-					$where .= " $table_name.media_title LIKE '%" . $search . "%' ";
+					$where .= $wpdb->prepare( " $table_name.media_title LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				} elseif ( 'description' === $search_by ) {
-					$where .= " post_table.post_content LIKE '%" . $search . "%'";
+					$where .= $wpdb->prepare( " post_table.post_content LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' );
 
 				} elseif ( 'author' === $search_by ) {
 					if ( ! empty( $author_id ) ) {
@@ -796,24 +798,24 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			} else {
 
 				if ( ! empty( $rtmedia_current_album ) ) {
-					$where .= " $table_name.album_id = '" . $rtmedia_current_album . "' AND ";
+					$where .= $wpdb->prepare( " $table_name.album_id = %s AND ", $rtmedia_current_album ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 
 				if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
-					$where .= " $table_name.media_type = '" . $media_type . "' AND ";
+					$where .= $wpdb->prepare( " $table_name.media_type = %s AND ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 				$where .= ' ( ';
-				$where .= " $table_name.media_title LIKE '%" . $search . "%' ";
+				$where .= $wpdb->prepare( " $table_name.media_title LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				if ( ! empty( $author_id ) ) {
 					$where .= " OR $table_name.media_author IN  (" . $author_id . ') ';
 				}
 				if ( ! empty( $member_type ) ) {
 					$where .= " OR $table_name.media_author IN  (" . $member_type . ') ';
 				}
-				$where .= " OR post_table.post_content LIKE '%" . $search . "%'";
+				$where .= $wpdb->prepare( " OR post_table.post_content LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' );
 
 				if ( empty( $media_type ) ) {
-					$where .= " OR $table_name.media_type = '" . $search . "' ";
+					$where .= $wpdb->prepare( " OR $table_name.media_type = %s ", $search ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				}
 
 				$where .= ' ) ';
@@ -822,12 +824,12 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 
 			// Reset data for album's media.
 			if ( '' !== $search && ! empty( $rtmedia_current_album ) ) {
-					$where .= " AND $table_name.album_id = '" . $rtmedia_current_album . "' ";
+					$where .= $wpdb->prepare( " AND $table_name.album_id = %s ", $rtmedia_current_album ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}
 
 			// Reset data for particular media type.
 			if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
-				$where .= " AND $table_name.media_type = '" . $media_type . "' ";
+				$where .= $wpdb->prepare( " AND $table_name.media_type = %s ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}
 		} // End if.
 	} // End if.
@@ -872,7 +874,7 @@ function rtmedia_search_fillter_join_query( $join, $table_name ) {
 			$request_url = explode( '/', $request_uri );
 			if ( ! empty( $search_by ) && 'attribute' === $search_by && ! in_array( 'attribute', $request_url, true ) ) {
 				$join .= " 	INNER JOIN $posts_table ON ( $posts_table.ID = $table_name.media_id AND $posts_table.post_type = '$media_type' )
-		                    INNER JOIN $terms_table ON ( $terms_table.slug IN ('" . $search . "') )
+		                    INNER JOIN $terms_table ON ( $terms_table.slug IN (" . $wpdb->prepare( '%s', $search ) . ") )
 		                    INNER JOIN $term_taxonomy_table ON ( $term_taxonomy_table.term_id = $terms_table.term_id )
 		                    INNER JOIN $term_relationships_table ON ( $term_relationships_table.term_taxonomy_id = $term_taxonomy_table.term_taxonomy_id AND $term_relationships_table.object_id = $posts_table.ID ) ";
 			}

--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -751,7 +751,7 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 
 		$raw_search = wp_unslash( filter_input( INPUT_GET, 'search', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
-		if ( 'string' !== gettype( $raw_search ) ) {
+		if ( ! is_string( $raw_search ) ) {
 			$raw_search = '';
 		}
 
@@ -874,10 +874,11 @@ function rtmedia_search_fillter_join_query( $join, $table_name ) {
 			$request_url = explode( '/', $request_uri );
 			if ( ! empty( $search_by ) && 'attribute' === $search_by && ! in_array( 'attribute', $request_url, true ) ) {
 				$join .= $wpdb->prepare(
-					" 	INNER JOIN $posts_table ON ( $posts_table.ID = $table_name.media_id AND $posts_table.post_type = '$media_type' )
-		                    INNER JOIN $terms_table ON ( $terms_table.slug IN (%s) )
+					" 	INNER JOIN $posts_table ON ( $posts_table.ID = $table_name.media_id AND $posts_table.post_type = %s )
+		                    INNER JOIN $terms_table ON ( $terms_table.slug = %s )
 		                    INNER JOIN $term_taxonomy_table ON ( $term_taxonomy_table.term_id = $terms_table.term_id )
 		                    INNER JOIN $term_relationships_table ON ( $term_relationships_table.term_taxonomy_id = $term_taxonomy_table.term_taxonomy_id AND $term_relationships_table.object_id = $posts_table.ID ) ",
+					$media_type,
 					$search
 				); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			}

--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -775,15 +775,15 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			if ( ! empty( $search_by ) ) {
 
 				if ( ! empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " $table_name.album_id = %d AND ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.album_id = %d AND ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				}
 
 				if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " $table_name.media_type = %s AND ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.media_type = %s AND ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				}
 
 				if ( 'title' === $search_by ) {
-					$where .= $wpdb->prepare( " $table_name.media_title LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.media_title LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				} elseif ( 'description' === $search_by ) {
 					$where .= $wpdb->prepare( " post_table.post_content LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' );
 
@@ -801,14 +801,14 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			} else {
 
 				if ( ! empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " $table_name.album_id = %d AND ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.album_id = %d AND ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				}
 
 				if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " $table_name.media_type = %s AND ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " $table_name.media_type = %s AND ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				}
 				$where .= ' ( ';
-				$where .= $wpdb->prepare( " $table_name.media_title LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$where .= $wpdb->prepare( " $table_name.media_title LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				if ( ! empty( $author_id ) ) {
 					$where .= " OR $table_name.media_author IN  (" . $author_id . ') ';
 				}
@@ -818,7 +818,7 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 				$where .= $wpdb->prepare( " OR post_table.post_content LIKE %s ", '%' . $wpdb->esc_like( $search ) . '%' );
 
 				if ( empty( $media_type ) ) {
-					$where .= $wpdb->prepare( " OR $table_name.media_type = %s ", $search ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " OR $table_name.media_type = %s ", $search ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 				}
 
 				$where .= ' ) ';
@@ -827,12 +827,12 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 
 			// Reset data for album's media.
 			if ( '' !== $search && ! empty( $rtmedia_current_album ) ) {
-					$where .= $wpdb->prepare( " AND $table_name.album_id = %d ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$where .= $wpdb->prepare( " AND $table_name.album_id = %d ", absint( $rtmedia_current_album ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 			}
 
 			// Reset data for particular media type.
 			if ( ! empty( $media_type ) && empty( $rtmedia_current_album ) ) {
-				$where .= $wpdb->prepare( " AND $table_name.media_type = %s ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$where .= $wpdb->prepare( " AND $table_name.media_type = %s ", $media_type ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 			}
 		} // End if.
 	} // End if.
@@ -883,7 +883,7 @@ function rtmedia_search_fillter_join_query( $join, $table_name ) {
 		                    INNER JOIN $term_relationships_table ON ( $term_relationships_table.term_taxonomy_id = $term_taxonomy_table.term_taxonomy_id AND $term_relationships_table.object_id = $posts_table.ID ) ",
 					$media_type,
 					$search
-				); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Interpolated values are trusted internal table/column identifiers, not user input.
 			}
 		}
 	}

--- a/app/main/controllers/template/rtmedia-filters.php
+++ b/app/main/controllers/template/rtmedia-filters.php
@@ -764,6 +764,9 @@ function rtmedia_search_fillter_where_query( $where, $table_name ) {
 			$author_id   = rtm_select_user( $search );
 			$member_type = rtm_fetch_user_by_member_type( $search );
 
+			$author_id   = implode( ',', array_map( 'absint', array_filter( explode( ',', $author_id ) ) ) );
+			$member_type = implode( ',', array_map( 'absint', array_filter( explode( ',', $member_type ) ) ) );
+
 			if ( ! empty( $rtmedia_current_album ) ) {
 				$where = '';
 			}

--- a/app/main/controllers/template/rtmedia-functions.php
+++ b/app/main/controllers/template/rtmedia-functions.php
@@ -4324,7 +4324,7 @@ function rtm_select_user( $user ) {
 		}
 	}
 
-	$user_id = implode( ',', $user_ids );
+	$user_id = implode( ',', array_map( 'absint', $user_ids ) );
 	return $user_id;
 }
 
@@ -4357,7 +4357,7 @@ function rtm_fetch_user_by_member_type( $type ) {
 				array_push( $member_id, bp_get_member_user_id() );
 			}
 		}
-		$member_id = implode( ',', $member_id );
+		$member_id = implode( ',', array_map( 'absint', $member_id ) );
 	}
 
 	return $member_id;


### PR DESCRIPTION
Refactors the WHERE/JOIN construction in the gallery search filters (`rtmedia_search_fillter_where_query` / `rtmedia_search_fillter_join_query`) to build clauses with `$wpdb->prepare()` and `$wpdb->esc_like()` instead of manual string concatenation, and drops a redundant decode of the already-decoded search parameter. No change to search behavior.