### PR TITLE
Security: Harden order_by parameter sanitization

### DIFF
--- a/app/helper/RTMediaModel.php
+++ b/app/helper/RTMediaModel.php
@@ -122,18 +122,16 @@ class RTMediaModel extends RTDBModel {
 		$qgroup_by = ' ';
 
 		$allowed_order_columns = array( 'media_id', 'media_title', 'file_size' ); // Define allowed columns.
+		$allowed_order_dirs    = array( 'asc', 'desc', '' );
 		list( $order_column, $order_direction ) = explode( ' ', $order_by . ' ' ); // Default to space if no direction provided.
 
-		if ( ! in_array( strtolower( $order_column ), $allowed_order_columns ) || ! in_array(
-			strtolower( $order_direction ),
-			array(
-				'asc',
-				'desc',
-				'',
-			)
-		) ) {
-			$order_by = 'media_id desc'; // Default order.
+		if ( ! in_array( strtolower( $order_column ), $allowed_order_columns, true ) || ! in_array( strtolower( $order_direction ), $allowed_order_dirs, true ) ) {
+			$order_column    = 'media_id';
+			$order_direction = 'desc';
 		}
+
+		// Reconstruct order_by from validated tokens only to prevent injection via trailing content.
+		$order_by = trim( $order_column . ' ' . $order_direction );
 
 		if ( $order_by ) {
 			$order_by  = esc_sql( $order_by );


### PR DESCRIPTION
## Summary

Strengthens input sanitization for the `order_by` parameter in
`RTMediaModel::get()` to ensure only validated values are used
in query construction.

## Changes

- Reconstruct `order_by` from individually validated tokens
  rather than passing through the original input string
- Use strict comparison for allowlist checks

## Testing

- Verified gallery queries work correctly with default and
  allowed order_by values
<img width="1918" height="1256" alt="image" src="https://github.com/user-attachments/assets/fc1f565d-aef4-4e4f-a0bc-ee3a64e68675" />
