### PR TITLE
hotfix- Security array lookup

### DIFF
--- a/app/main/controllers/api/RTMediaJsonApiFunctions.php
+++ b/app/main/controllers/api/RTMediaJsonApiFunctions.php
@@ -328,7 +328,8 @@ class RTMediaJsonApiFunctions {
 
 						$viewable_media_ids = array();
 						foreach ( $viewable_media as $media_row ) {
-							$viewable_media_ids[] = intval( $media_row->id );
+							// get_by_activity_id() returns ARRAY_A rows, but callers may pass objects.
+							$viewable_media_ids[] = intval( is_array( $media_row ) ? $media_row['id'] : $media_row->id );
 						}
 
 						$activity_text = bp_activity_get_meta( $activities_template->activity->id, 'bp_activity_text' );


### PR DESCRIPTION
## What

One-line fix in `app/main/controllers/api/RTMediaJsonApiFunctions.php`.

`RTMediaModel::get_by_activity_id()` returns `ARRAY_A` rows, but the media-id extraction added in b289b1d9a (merged via #2357) reads `$media_row->id` on an array.

## Impact

Every JSON API call that builds a media feed (`rtmedia_get_media_details`, and any feed path where the activity has media rows):

- emits `PHP Warning: Attempt to read property "id" on array`
- computes `intval(null)` = `0`, so `RTMediaActivity` is constructed with `[0]` and `activity_content` renders as an empty media list

Before:
```
"activity_content": "<div class=\"rtmedia-activity-container\"><ul class=\"... rtmedia-activity-media-length-0 rtm-activity-mixed-list\"></ul></div>"
```

After:
```
"activity_content": "<div class=\"rtmedia-activity-container\"><ul class=\"... rtmedia-activity-media-length-1 rtm-activity-photo-list\"><li ...><img .../></li></ul></div>"
```

The `media` array in the response was always correct — only `activity_content` was affected.

## Security

None. The privacy gate immediately above this loop casts to object via `(object) $media`, so it handles both row shapes and visibility filtering was never affected. Verified after the fix:

| user | media 8 (privacy 60, alice) | media 12 (privacy 80, alice) | media 10 (public) |
|---|---|---|---|
| bob (non-owner) | FALSE | FALSE | TRUE |
| alice (owner) | TRUE | TRUE | TRUE |

## Testing

Reproduced and verified against a local BuddyPress + rtMedia site with token-authenticated API calls: warning count for `RTMediaJsonApiFunctions` dropped to 0, `activity_content` renders the correct thumbnail, and the privacy matrix above is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)