### PR TITLE
Fix predictable API token vulnerability

### DIFF
--- a/app/main/controllers/api/RTMediaJsonApi.php
+++ b/app/main/controllers/api/RTMediaJsonApi.php
@@ -347,7 +347,7 @@ class RTMediaJsonApi {
 					'user_id'    => intval( $user_login->ID ),
 					'ip'         => $remote_addr,
 					'token'      => sanitize_text_field( $access_token ),
-					'token_time' => date( 'Y-m-d H:i:s' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+					'token_time' => time(),
 				);
 				$rtmapilogin->insert( $login_details );
 				wp_send_json( $this->rtmedia_api_response_object( 'TRUE', $ec_login_success, $msg_login_success, $data ) );

--- a/app/main/controllers/api/RTMediaJsonApiFunctions.php
+++ b/app/main/controllers/api/RTMediaJsonApiFunctions.php
@@ -28,9 +28,9 @@ class RTMediaJsonApiFunctions {
 		if ( empty( $user_id ) || empty( $user_login ) ) {
 			return false;
 		}
-		$string = '08~' . $user_id . '~' . $user_login . '~kumar';
 
-		return sha1( $string . current_time( 'timestamp' ) . wp_rand( 1, 9 ) );
+		// Generate an opaque 64 character long token for user login.
+		return wp_generate_password( 64, false, false );
 	}
 
 	/**

--- a/app/main/controllers/api/RTMediaJsonApiFunctions.php
+++ b/app/main/controllers/api/RTMediaJsonApiFunctions.php
@@ -12,6 +12,13 @@
 class RTMediaJsonApiFunctions {
 
 	/**
+	 * Token lifetime in seconds.
+	 *
+	 * @var int
+	 */
+	public $token_lifetime = 2592000; // 30 days.
+
+	/**
 	 * RTMediaJsonApiFunctions constructor.
 	 */
 	public function __construct() {}
@@ -31,6 +38,17 @@ class RTMediaJsonApiFunctions {
 
 		// Generate an opaque 64 character long token for user login.
 		return wp_generate_password( 64, false, false );
+	}
+
+	/**
+	 * Get the absolute API token lifetime in seconds.
+	 *
+	 * @return int
+	 */
+	public function rtmedia_api_get_token_lifetime() {
+		$token_lifetime = (int) apply_filters( 'rtmedia_api_token_lifetime', $this->token_lifetime );
+
+		return max( MINUTE_IN_SECONDS, $token_lifetime );
 	}
 
 	/**
@@ -96,6 +114,11 @@ class RTMediaJsonApiFunctions {
 			return false;
 		}
 
+		// Revoke predictable 40-character SHA-1 tokens issued by affected versions.
+		if ( 1 !== preg_match( '/^[A-Za-z0-9]{64}$/D', $token ) ) {
+			return false;
+		}
+
 		if ( class_exists( 'RTMediaApiLogin' ) ) {
 			$rtmediaapilogin = new RTMediaApiLogin();
 			$columns         = array(
@@ -103,6 +126,15 @@ class RTMediaJsonApiFunctions {
 			);
 			$token_data      = $rtmediaapilogin->get( $columns );
 			if ( empty( $token_data ) || 'FALSE' === $token_data[0]->status ) {
+				return false;
+			}
+
+			$issued_at  = isset( $token_data[0]->token_time ) ? (int) $token_data[0]->token_time : 0;
+			$expires_at = $issued_at + $this->rtmedia_api_get_token_lifetime();
+
+			if ( $issued_at <= 0 || time() >= $expires_at ) {
+				$rtmediaapilogin->update( array( 'status' => 'FALSE' ), array( 'id' => $token_data[0]->id ) );
+
 				return false;
 			}
 
@@ -124,6 +156,9 @@ class RTMediaJsonApiFunctions {
 			return false;
 		}
 		$token_data = $this->rtmedia_api_validate_token( $token );
+		if ( empty( $token_data ) ) {
+				return false;
+		}
 
 		return $token_data[0]->user_id;
 	}


### PR DESCRIPTION
Fixes a security issue where API tokens could be predicted and brute-forced.

### Changes

- Generate secure 64-character random tokens.
- Reject old 40-character tokens.
- Expire API tokens after 30 days.
- Revoke expired tokens.

**Note:** Existing API users will need to log in again to receive a new token.