### PR TITLE
fix: add rate limiting for API authentication and token validation

### DIFF
--- a/app/main/controllers/api/RTMediaApiRateLimiter.php
+++ b/app/main/controllers/api/RTMediaApiRateLimiter.php
@@ -21,6 +21,13 @@ class RTMediaApiRateLimiter {
 	const CACHE_GROUP = 'rtmedia_api_rate_limit';
 
 	/**
+	 * Suffix used for object-cache bucket expiry metadata.
+	 *
+	 * @var string
+	 */
+	const EXPIRY_KEY_SUFFIX = '_expires_at';
+
+	/**
 	 * Default rate-limit window in seconds.
 	 *
 	 * @var int
@@ -56,8 +63,33 @@ class RTMediaApiRateLimiter {
 	 * @return bool
 	 */
 	public function is_login_blocked( $identifier ) {
-		return $this->get_attempts( $this->get_key( 'login_ip', $this->get_client_ip() ) ) >= $this->get_login_ip_limit()
-			|| $this->get_attempts( $this->get_key( 'login_id', $this->normalize_identifier( $identifier ) ) ) >= $this->get_login_identifier_limit();
+		return 0 < $this->get_login_retry_after( $identifier );
+	}
+
+	/**
+	 * Get the remaining time for blocked login buckets.
+	 *
+	 * When both the client IP and identifier buckets are blocking, the client
+	 * must wait until both have expired, so return the longer remaining TTL.
+	 *
+	 * @param string $identifier Username or email address supplied for login.
+	 *
+	 * @return int Remaining seconds, or zero when the login is not blocked.
+	 */
+	public function get_login_retry_after( $identifier ) {
+		$ip_key         = $this->get_key( 'login_ip', $this->get_client_ip() );
+		$identifier_key = $this->get_key( 'login_id', $this->normalize_identifier( $identifier ) );
+		$retry_after    = 0;
+
+		if ( $this->get_attempts( $ip_key ) >= $this->get_login_ip_limit() ) {
+			$retry_after = max( 1, $this->get_remaining_ttl( $ip_key ) );
+		}
+
+		if ( $this->get_attempts( $identifier_key ) >= $this->get_login_identifier_limit() ) {
+			$retry_after = max( $retry_after, 1, $this->get_remaining_ttl( $identifier_key ) );
+		}
+
+		return $retry_after;
 	}
 
 	/**
@@ -88,7 +120,22 @@ class RTMediaApiRateLimiter {
 	 * @return bool
 	 */
 	public function is_token_validation_blocked() {
-		return $this->get_attempts( $this->get_key( 'token_ip', $this->get_client_ip() ) ) >= $this->get_token_limit();
+		return 0 < $this->get_token_retry_after();
+	}
+
+	/**
+	 * Get the remaining time for a blocked token-validation bucket.
+	 *
+	 * @return int Remaining seconds, or zero when token validation is not blocked.
+	 */
+	public function get_token_retry_after() {
+		$key = $this->get_key( 'token_ip', $this->get_client_ip() );
+
+		if ( $this->get_attempts( $key ) < $this->get_token_limit() ) {
+			return 0;
+		}
+
+		return max( 1, $this->get_remaining_ttl( $key ) );
 	}
 
 	/**
@@ -130,10 +177,21 @@ class RTMediaApiRateLimiter {
 		$window = $this->get_window();
 
 		if ( wp_using_ext_object_cache() ) {
+			$now        = time();
+			$expiry_key = $this->get_expiry_key( $key );
+
 			// Seed the key only if absent; wp_cache_add() itself is atomic
 			// (no-op if the key already exists), so this never clobbers an
 			// in-flight counter from a concurrent request.
-			wp_cache_add( $key, 0, self::CACHE_GROUP, $window );
+			$counter_added = wp_cache_add( $key, 0, self::CACHE_GROUP, $window );
+
+			// WordPress does not expose a cached key's remaining TTL. Store
+			// the absolute expiry separately so Retry-After can be accurate.
+			if ( $counter_added ) {
+				wp_cache_set( $expiry_key, $now + $window, self::CACHE_GROUP, $window );
+			} else {
+				wp_cache_add( $expiry_key, $now + $window, self::CACHE_GROUP, $window );
+			}
 
 			$count = wp_cache_incr( $key, 1, self::CACHE_GROUP );
 
@@ -141,6 +199,7 @@ class RTMediaApiRateLimiter {
 			// the add() above and the incr() call. Reseed at 1 in that case.
 			if ( false === $count ) {
 				wp_cache_set( $key, 1, self::CACHE_GROUP, $window );
+				wp_cache_set( $expiry_key, $now + $window, self::CACHE_GROUP, $window );
 				$count = 1;
 			}
 
@@ -202,6 +261,39 @@ class RTMediaApiRateLimiter {
 	}
 
 	/**
+	 * Get the remaining lifetime of a bucket.
+	 *
+	 * @param string $key Bucket key.
+	 *
+	 * @return int Remaining seconds, or zero when no valid expiry is available.
+	 */
+	private function get_remaining_ttl( $key ) {
+		if ( wp_using_ext_object_cache() ) {
+			$expires_at = wp_cache_get( $this->get_expiry_key( $key ), self::CACHE_GROUP );
+
+			// Counters created before expiry metadata was introduced may remain
+			// active for one window. Use the full window as a safe fallback.
+			if ( false === $expires_at || ! is_numeric( $expires_at ) ) {
+				return $this->get_window();
+			}
+
+			return max( 0, (int) $expires_at - time() );
+		}
+
+		$bucket = get_transient( $key );
+
+		if (
+			! is_array( $bucket )
+			|| ! isset( $bucket['expires_at'] )
+			|| ! is_numeric( $bucket['expires_at'] )
+		) {
+			return 0;
+		}
+
+		return max( 0, (int) $bucket['expires_at'] - time() );
+	}
+
+	/**
 	 * Delete a bucket, regardless of backend.
 	 *
 	 * @param string $key Bucket key.
@@ -209,6 +301,7 @@ class RTMediaApiRateLimiter {
 	private function delete( $key ) {
 		if ( wp_using_ext_object_cache() ) {
 			wp_cache_delete( $key, self::CACHE_GROUP );
+			wp_cache_delete( $this->get_expiry_key( $key ), self::CACHE_GROUP );
 
 			return;
 		}
@@ -226,6 +319,17 @@ class RTMediaApiRateLimiter {
 	 */
 	private function get_key( $scope, $identifier ) {
 		return 'rtm_api_rl_' . $scope . '_' . substr( wp_hash( (string) $identifier, 'auth' ), 0, 32 );
+	}
+
+	/**
+	 * Get the companion object-cache key for a bucket's absolute expiry.
+	 *
+	 * @param string $key Bucket key.
+	 *
+	 * @return string
+	 */
+	private function get_expiry_key( $key ) {
+		return $key . self::EXPIRY_KEY_SUFFIX;
 	}
 
 	/**

--- a/app/main/controllers/api/RTMediaApiRateLimiter.php
+++ b/app/main/controllers/api/RTMediaApiRateLimiter.php
@@ -21,6 +21,34 @@ class RTMediaApiRateLimiter {
 	const CACHE_GROUP = 'rtmedia_api_rate_limit';
 
 	/**
+	 * Default rate-limit window in seconds.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_WINDOW = 300;
+
+	/**
+	 * Default maximum login failures per IP address.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_LOGIN_IP_LIMIT = 20;
+
+	/**
+	 * Default maximum login failures per identifier.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_LOGIN_IDENTIFIER_LIMIT = 5;
+
+	/**
+	 * Default maximum invalid token submissions per IP address.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_TOKEN_ATTEMPT_LIMIT = 20;
+
+	/**
 	 * Check whether a login attempt should be blocked.
 	 *
 	 * @param string $identifier Username or email address supplied for login.
@@ -76,7 +104,7 @@ class RTMediaApiRateLimiter {
 	 * @return int
 	 */
 	public function get_window() {
-		$window = (int) apply_filters( 'rtmedia_api_rate_limit_window', 5 * MINUTE_IN_SECONDS );
+		$window = (int) apply_filters( 'rtmedia_api_rate_limit_window', self::DEFAULT_WINDOW );
 
 		return max( MINUTE_IN_SECONDS, $window );
 	}
@@ -217,7 +245,7 @@ class RTMediaApiRateLimiter {
 	 * @return int
 	 */
 	private function get_login_ip_limit() {
-		return max( 1, (int) apply_filters( 'rtmedia_api_login_ip_limit', 20 ) );
+		return max( 1, (int) apply_filters( 'rtmedia_api_login_ip_limit', self::DEFAULT_LOGIN_IP_LIMIT ) );
 	}
 
 	/**
@@ -226,7 +254,7 @@ class RTMediaApiRateLimiter {
 	 * @return int
 	 */
 	private function get_login_identifier_limit() {
-		return max( 1, (int) apply_filters( 'rtmedia_api_login_identifier_limit', 5 ) );
+		return max( 1, (int) apply_filters( 'rtmedia_api_login_identifier_limit', self::DEFAULT_LOGIN_IDENTIFIER_LIMIT ) );
 	}
 
 	/**
@@ -235,6 +263,6 @@ class RTMediaApiRateLimiter {
 	 * @return int
 	 */
 	private function get_token_limit() {
-		return max( 1, (int) apply_filters( 'rtmedia_api_token_attempt_limit', 20 ) );
+		return max( 1, (int) apply_filters( 'rtmedia_api_token_attempt_limit', self::DEFAULT_TOKEN_ATTEMPT_LIMIT ) );
 	}
 }

--- a/app/main/controllers/api/RTMediaApiRateLimiter.php
+++ b/app/main/controllers/api/RTMediaApiRateLimiter.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Rate limiting for rtMedia API authentication.
+ *
+ * @package rtMedia
+ */
+
+/**
+ * Apply per-client and per-identifier limits to API authentication attempts.
+ */
+class RTMediaApiRateLimiter {
+
+	/**
+	 * Object cache group used for rate-limit counters.
+	 *
+	 * Only relevant when a persistent object cache (Redis, Memcached, etc.)
+	 * is active; otherwise counters fall back to transients.
+	 *
+	 * @var string
+	 */
+	const CACHE_GROUP = 'rtmedia_api_rate_limit';
+
+	/**
+	 * Check whether a login attempt should be blocked.
+	 *
+	 * @param string $identifier Username or email address supplied for login.
+	 *
+	 * @return bool
+	 */
+	public function is_login_blocked( $identifier ) {
+		return $this->get_attempts( $this->get_key( 'login_ip', $this->get_client_ip() ) ) >= $this->get_login_ip_limit()
+			|| $this->get_attempts( $this->get_key( 'login_id', $this->normalize_identifier( $identifier ) ) ) >= $this->get_login_identifier_limit();
+	}
+
+	/**
+	 * Record a failed login attempt.
+	 *
+	 * @param string $identifier Username or email address supplied for login.
+	 */
+	public function record_login_failure( $identifier ) {
+		$this->increment( $this->get_key( 'login_ip', $this->get_client_ip() ) );
+		$this->increment( $this->get_key( 'login_id', $this->normalize_identifier( $identifier ) ) );
+	}
+
+	/**
+	 * Clear the identifier bucket after a successful login.
+	 *
+	 * The IP bucket is deliberately retained so an attacker cannot reset it by
+	 * successfully authenticating an account they control.
+	 *
+	 * @param string $identifier Username or email address supplied for login.
+	 */
+	public function clear_login_identifier( $identifier ) {
+		$this->delete( $this->get_key( 'login_id', $this->normalize_identifier( $identifier ) ) );
+	}
+
+	/**
+	 * Check whether invalid token submissions should be blocked for this client.
+	 *
+	 * @return bool
+	 */
+	public function is_token_validation_blocked() {
+		return $this->get_attempts( $this->get_key( 'token_ip', $this->get_client_ip() ) ) >= $this->get_token_limit();
+	}
+
+	/**
+	 * Record an invalid token submission.
+	 */
+	public function record_token_failure() {
+		$this->increment( $this->get_key( 'token_ip', $this->get_client_ip() ) );
+	}
+
+	/**
+	 * Return the rate-limit window in seconds.
+	 *
+	 * @return int
+	 */
+	public function get_window() {
+		$window = (int) apply_filters( 'rtmedia_api_rate_limit_window', 5 * MINUTE_IN_SECONDS );
+
+		return max( MINUTE_IN_SECONDS, $window );
+	}
+
+	/**
+	 * Increment a rate-limit bucket and return the new count.
+	 *
+	 * When a persistent object cache is active (Redis, Memcached, etc.), the
+	 * increment is atomic: wp_cache_add() seeds the key exactly once and
+	 * wp_cache_incr() is a single atomic operation on the cache backend, so
+	 * concurrent requests cannot race on a read-modify-write cycle.
+	 *
+	 * Without a persistent object cache, this falls back to a transient
+	 * (stored in wp_options). That fallback is NOT atomic: two concurrent
+	 * requests can both read the same count and both write count+1, silently
+	 * losing an increment.
+	 *
+	 * @param string $key Bucket key.
+	 *
+	 * @return int
+	 */
+	private function increment( $key ) {
+		$window = $this->get_window();
+
+		if ( wp_using_ext_object_cache() ) {
+			// Seed the key only if absent; wp_cache_add() itself is atomic
+			// (no-op if the key already exists), so this never clobbers an
+			// in-flight counter from a concurrent request.
+			wp_cache_add( $key, 0, self::CACHE_GROUP, $window );
+
+			$count = wp_cache_incr( $key, 1, self::CACHE_GROUP );
+
+			// wp_cache_incr() can return false if the key expired between
+			// the add() above and the incr() call. Reseed at 1 in that case.
+			if ( false === $count ) {
+				wp_cache_set( $key, 1, self::CACHE_GROUP, $window );
+				$count = 1;
+			}
+
+			return (int) $count;
+		}
+
+		// Transient fallback — see race-condition note in the docblock above.
+		$count = $this->get_attempts( $key ) + 1;
+		set_transient( $key, $count, $window );
+
+		return $count;
+	}
+
+	/**
+	 * Get the number of attempts in a bucket.
+	 *
+	 * @param string $key Bucket key.
+	 *
+	 * @return int
+	 */
+	private function get_attempts( $key ) {
+		if ( wp_using_ext_object_cache() ) {
+			$count = wp_cache_get( $key, self::CACHE_GROUP );
+
+			return false === $count ? 0 : (int) $count;
+		}
+
+		return (int) get_transient( $key );
+	}
+
+	/**
+	 * Delete a bucket, regardless of backend.
+	 *
+	 * @param string $key Bucket key.
+	 */
+	private function delete( $key ) {
+		if ( wp_using_ext_object_cache() ) {
+			wp_cache_delete( $key, self::CACHE_GROUP );
+
+			return;
+		}
+
+		delete_transient( $key );
+	}
+
+	/**
+	 * Create a bounded, non-reversible bucket key.
+	 *
+	 * @param string $scope      Rate-limit scope.
+	 * @param string $identifier Client or login identifier.
+	 *
+	 * @return string
+	 */
+	private function get_key( $scope, $identifier ) {
+		return 'rtm_api_rl_' . $scope . '_' . substr( wp_hash( (string) $identifier, 'auth' ), 0, 32 );
+	}
+
+	/**
+	 * Get the client IP address to key rate limits on.
+	 *
+	 * By default only REMOTE_ADDR is trusted. Proxy headers such as
+	 * X-Forwarded-For or CF-Connecting-IP are never read here because they
+	 * can be forged by the client unless a specific, known reverse proxy
+	 * strips and rewrites them first — and this plugin has no way to know
+	 * whether that's true for any given install.
+	 *
+	 * @return string
+	 */
+	private function get_client_ip() {
+		$remote_addr = rtm_get_server_var( 'REMOTE_ADDR', 'FILTER_VALIDATE_IP' );
+		$remote_addr = $remote_addr ? $remote_addr : 'unknown';
+
+		/**
+		 * Filters the client IP address used for API rate limiting.
+		 *
+		 * @param string $remote_addr The address read from REMOTE_ADDR.
+		 */
+		$client_ip = apply_filters( 'rtmedia_api_client_ip', $remote_addr );
+
+		$client_ip = is_string( $client_ip ) ? trim( $client_ip ) : '';
+
+		// Validate whatever the filter returned; never trust it blindly,
+		// since a badly written filter could hand back attacker-controlled
+		// input straight from an unvalidated header.
+		return filter_var( $client_ip, FILTER_VALIDATE_IP ) ? $client_ip : 'unknown';
+	}
+
+	/**
+	 * Normalize a login identifier before deriving its rate-limit key.
+	 *
+	 * @param string $identifier Username or email address.
+	 *
+	 * @return string
+	 */
+	private function normalize_identifier( $identifier ) {
+		return strtolower( trim( (string) $identifier ) );
+	}
+
+	/**
+	 * Get the maximum login failures allowed per IP address.
+	 *
+	 * @return int
+	 */
+	private function get_login_ip_limit() {
+		return max( 1, (int) apply_filters( 'rtmedia_api_login_ip_limit', 20 ) );
+	}
+
+	/**
+	 * Get the maximum login failures allowed per identifier.
+	 *
+	 * @return int
+	 */
+	private function get_login_identifier_limit() {
+		return max( 1, (int) apply_filters( 'rtmedia_api_login_identifier_limit', 5 ) );
+	}
+
+	/**
+	 * Get the maximum invalid token submissions allowed per IP address.
+	 *
+	 * @return int
+	 */
+	private function get_token_limit() {
+		return max( 1, (int) apply_filters( 'rtmedia_api_token_attempt_limit', 20 ) );
+	}
+}

--- a/app/main/controllers/api/RTMediaApiRateLimiter.php
+++ b/app/main/controllers/api/RTMediaApiRateLimiter.php
@@ -148,8 +148,26 @@ class RTMediaApiRateLimiter {
 		}
 
 		// Transient fallback — see race-condition note in the docblock above.
-		$count = $this->get_attempts( $key ) + 1;
-		set_transient( $key, $count, $window );
+		$now    = time();
+		$bucket = get_transient( $key );
+
+		if (
+			! is_array( $bucket )
+			|| ! isset( $bucket['count'], $bucket['expires_at'] )
+			|| ! is_numeric( $bucket['count'] )
+			|| ! is_numeric( $bucket['expires_at'] )
+			|| (int) $bucket['expires_at'] <= $now
+		) {
+			$bucket = array(
+				'count'      => 0,
+				'expires_at' => $now + $window,
+			);
+		}
+
+		$count           = (int) $bucket['count'] + 1;
+		$bucket['count'] = $count;
+		$remaining       = max( 1, (int) $bucket['expires_at'] - time() );
+		set_transient( $key, $bucket, $remaining );
 
 		return $count;
 	}
@@ -168,7 +186,19 @@ class RTMediaApiRateLimiter {
 			return false === $count ? 0 : (int) $count;
 		}
 
-		return (int) get_transient( $key );
+		$bucket = get_transient( $key );
+
+		if (
+			! is_array( $bucket )
+			|| ! isset( $bucket['count'], $bucket['expires_at'] )
+			|| ! is_numeric( $bucket['count'] )
+			|| ! is_numeric( $bucket['expires_at'] )
+			|| (int) $bucket['expires_at'] <= time()
+		) {
+			return 0;
+		}
+
+		return (int) $bucket['count'];
 	}
 
 	/**

--- a/app/main/controllers/api/RTMediaJsonApi.php
+++ b/app/main/controllers/api/RTMediaJsonApi.php
@@ -323,7 +323,7 @@ class RTMediaJsonApi {
 		$ec_invalid_credentials  = 200003;
 		$msg_invalid_credentials = esc_html__( 'invalid username or password', 'buddypress-media' );
 
-		$ec_login_rate_limited  = 200005;
+		$ec_login_rate_limited  = 200006;
 		$msg_login_rate_limited = esc_html__( 'too many login attempts; please try again later', 'buddypress-media' );
 
 		$ec_login_success  = 200004;

--- a/app/main/controllers/api/RTMediaJsonApi.php
+++ b/app/main/controllers/api/RTMediaJsonApi.php
@@ -138,6 +138,20 @@ class RTMediaJsonApi {
 	public $msg_api_disabled = 'API disabled by site administrator';
 
 	/**
+	 * Error code for rate-limited API requests.
+	 *
+	 * @var int
+	 */
+	public $ec_rate_limit_exceeded = 600010;
+
+	/**
+	 * Error message for rate-limited API requests.
+	 *
+	 * @var string
+	 */
+	public $msg_rate_limit_exceeded = 'too many requests; please try again later';
+
+	/**
 	 * Object of RTMediaJsonApiFunctions class to handle api requests.
 	 *
 	 * @var object
@@ -306,33 +320,37 @@ class RTMediaJsonApi {
 		$ec_user_pass_missing  = 200001;
 		$msg_user_pass_missing = esc_html__( 'username/password empty', 'buddypress-media' );
 
-		$ec_incorrect_username  = 200002;
-		$msg_incorrect_username = esc_html__( 'incorrect username', 'buddypress-media' );
+		$ec_invalid_credentials  = 200003;
+		$msg_invalid_credentials = esc_html__( 'invalid username or password', 'buddypress-media' );
 
-		$ec_incorrect_pass  = 200003;
-		$msg_incorrect_pass = esc_html__( 'incorrect password', 'buddypress-media' );
+		$ec_login_rate_limited  = 200005;
+		$msg_login_rate_limited = esc_html__( 'too many login attempts; please try again later', 'buddypress-media' );
 
 		$ec_login_success  = 200004;
 		$msg_login_success = esc_html__( 'login success', 'buddypress-media' );
-		$username          = sanitize_text_field( filter_input( INPUT_POST, 'username', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
-		$password          = sanitize_text_field( filter_input( INPUT_POST, 'password', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$username          = filter_input( INPUT_POST, 'username', FILTER_UNSAFE_RAW );
+		$password          = filter_input( INPUT_POST, 'password', FILTER_UNSAFE_RAW );
+		$username          = is_string( $username ) ? sanitize_text_field( $username ) : '';
+		$password          = is_string( $password ) ? $password : '';
 
 		if ( empty( $username ) || empty( $password ) ) {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_user_pass_missing, $msg_user_pass_missing ) );
 		} else {
-			$user_login = wp_authenticate( trim( $username ), trim( $password ) );
+			$rate_limiter = new RTMediaApiRateLimiter();
+
+			if ( $rate_limiter->is_login_blocked( $username ) ) {
+				header( 'Retry-After: ' . $rate_limiter->get_window() );
+				status_header( 429 );
+				wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_login_rate_limited, $msg_login_rate_limited ) );
+			}
+
+			$user_login = wp_authenticate( trim( $username ), $password );
 
 			if ( is_wp_error( $user_login ) ) {
-
-				$incorrect_password = ! empty( $user_login->errors['incorrect_password'] ) ? true : false;
-				$incorrect_username = ! empty( $user_login->errors['invalid_username'] ) ? true : false;
-
-				if ( $incorrect_password ) {
-					wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_incorrect_pass, $msg_incorrect_pass ) );
-				} elseif ( $incorrect_username ) {
-					wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_incorrect_username, $msg_incorrect_username ) );
-				}
+				$rate_limiter->record_login_failure( $username );
+				wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_invalid_credentials, $msg_invalid_credentials ) );
 			} else {
+				$rate_limiter->clear_login_identifier( $username );
 
 				$access_token = $this->rtmediajsonapifunction->rtmedia_api_get_user_token( $user_login->ID, $user_login->data->user_login );
 				$data         = array(

--- a/app/main/controllers/api/RTMediaJsonApi.php
+++ b/app/main/controllers/api/RTMediaJsonApi.php
@@ -337,9 +337,10 @@ class RTMediaJsonApi {
 			wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_user_pass_missing, $msg_user_pass_missing ) );
 		} else {
 			$rate_limiter = new RTMediaApiRateLimiter();
+			$retry_after  = $rate_limiter->get_login_retry_after( $username );
 
-			if ( $rate_limiter->is_login_blocked( $username ) ) {
-				header( 'Retry-After: ' . $rate_limiter->get_window() );
+			if ( 0 < $retry_after ) {
+				header( 'Retry-After: ' . $retry_after );
 				status_header( 429 );
 				wp_send_json( $this->rtmedia_api_response_object( 'FALSE', $ec_login_rate_limited, $msg_login_rate_limited ) );
 			}

--- a/app/main/controllers/api/RTMediaJsonApiFunctions.php
+++ b/app/main/controllers/api/RTMediaJsonApiFunctions.php
@@ -175,8 +175,10 @@ class RTMediaJsonApiFunctions {
 			wp_send_json( $rtmjsonapi->rtmedia_api_response_object( 'FALSE', $rtmjsonapi->ec_token_missing, $rtmjsonapi->msg_token_missing ) );
 		}
 
-		if ( $rate_limiter->is_token_validation_blocked() ) {
-			header( 'Retry-After: ' . $rate_limiter->get_window() );
+		$retry_after = $rate_limiter->get_token_retry_after();
+
+		if ( 0 < $retry_after ) {
+			header( 'Retry-After: ' . $retry_after );
 			status_header( 429 );
 			wp_send_json( $rtmjsonapi->rtmedia_api_response_object( 'FALSE', $rtmjsonapi->ec_rate_limit_exceeded, $rtmjsonapi->msg_rate_limit_exceeded ) );
 		}

--- a/app/main/controllers/api/RTMediaJsonApiFunctions.php
+++ b/app/main/controllers/api/RTMediaJsonApiFunctions.php
@@ -157,7 +157,7 @@ class RTMediaJsonApiFunctions {
 		}
 		$token_data = $this->rtmedia_api_validate_token( $token );
 		if ( empty( $token_data ) ) {
-				return false;
+			return false;
 		}
 
 		return $token_data[0]->user_id;
@@ -167,17 +167,25 @@ class RTMediaJsonApiFunctions {
 	 * Token processing for all data fetch/post requests
 	 */
 	public function rtmedia_api_verfiy_token() {
-		$rtmjsonapi = new RTMediaJsonApi();
-		$token      = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$rtmjsonapi   = new RTMediaJsonApi();
+		$rate_limiter = new RTMediaApiRateLimiter();
+		$token        = sanitize_text_field( filter_input( INPUT_POST, 'token', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		if ( empty( $token ) ) {
 			wp_send_json( $rtmjsonapi->rtmedia_api_response_object( 'FALSE', $rtmjsonapi->ec_token_missing, $rtmjsonapi->msg_token_missing ) );
+		}
+
+		if ( $rate_limiter->is_token_validation_blocked() ) {
+			header( 'Retry-After: ' . $rate_limiter->get_window() );
+			status_header( 429 );
+			wp_send_json( $rtmjsonapi->rtmedia_api_response_object( 'FALSE', $rtmjsonapi->ec_rate_limit_exceeded, $rtmjsonapi->msg_rate_limit_exceeded ) );
 		}
 
 		// Validate token.
 		$token_valid = $this->rtmedia_api_validate_token( $token );
 
 		if ( ! $token_valid ) {
+			$rate_limiter->record_token_failure();
 			wp_send_json( $rtmjsonapi->rtmedia_api_response_object( 'FALSE', $rtmjsonapi->ec_token_invalid, $rtmjsonapi->msg_token_invalid ) );
 		}
 	}


### PR DESCRIPTION
## Description

This PR adds rate limiting to rtMedia API authentication and token validation endpoints to reduce brute-force and token-guessing attempts.

## Changes

- Adds `RTMediaApiRateLimiter` for tracking failed authentication attempts.
- Applies separate limits for:
  - Login failures per client IP: `20 attempts per 5 minutes`.
  - Login failures per username/email identifier: `5 attempts per 5 minutes`.
  - Invalid API-token submissions per client IP: `20 attempts per 5 minutes`.
- Uses a default five-minute rate-limit window.
- Defines named constants for the default rate-limit window and attempt limits.
- Returns HTTP `429 Too Many Requests` with a `Retry-After` header when a limit is reached.
- Uses API status code `200006` for rate-limited login attempts.
- Replaces username-specific and password-specific login errors with a generic `invalid username or password` response to prevent username enumeration.
- Clears the identifier counter after successful authentication while retaining the IP counter.
- Hashes IP addresses and login identifiers before using them in cache keys.
- Provides filters for customizing the limits, window, and resolved client IP:

```php
rtmedia_api_rate_limit_window
rtmedia_api_login_ip_limit
rtmedia_api_login_identifier_limit
rtmedia_api_token_attempt_limit
rtmedia_api_client_ip
```

## Implementation details

When a persistent object cache such as Redis or Memcached is active, counters use `wp_cache_add()` and `wp_cache_incr()`.

When no persistent object cache is configured, counters fall back to WordPress transients.

By default, only `REMOTE_ADDR` is used to identify the client. Forwarded headers are not trusted automatically because they may be spoofed unless a trusted reverse proxy sanitizes them.

## Limitations

### Counter atomicity

Rate-limit increments are atomic only when the configured persistent object-cache backend provides atomic `add` and `increment` operations.

The transient fallback is not atomic. Concurrent requests can read the same counter value and overwrite one another, causing some attempts to go uncounted. Rate limiting therefore remains best-effort on installations without a persistent object cache.

There is also a small expiration race with persistent caches: if a key expires between `wp_cache_add()` and `wp_cache_incr()`, the fallback `wp_cache_set()` may overlap with another request. This does not disable rate limiting, but exact counting is not guaranteed at the window boundary.

### `REMOTE_ADDR` and reverse proxies

`REMOTE_ADDR` may represent a load balancer, CDN, or reverse proxy rather than the original client. On these installations, multiple users can share one rate-limit bucket and potentially rate-limit one another.

The `rtmedia_api_client_ip` filter allows an installation to resolve the client IP from infrastructure-specific headers. The callback must only accept headers that are stripped and rewritten by a trusted proxy.

IP-format validation alone does not make a forwarded header trustworthy - a client can still supply a syntactically valid but forged IP address if the proxy does not sanitize that header.